### PR TITLE
Implement stem-based keyword matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "dotenv": "^17.1.0",
+    "natural": "^8.1.0",
     "openai": "^5.8.2",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",

--- a/src/triggers/KeywordTrigger.ts
+++ b/src/triggers/KeywordTrigger.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'fs';
 import { Context } from 'telegraf';
 import { Trigger } from './Trigger';
+import { PorterStemmerRu as Stemmer } from 'natural';
 
 export class KeywordTrigger implements Trigger {
   private keywords: string[];
+  private stems: string[];
 
   constructor(filename: string) {
     const data = readFileSync(filename, 'utf-8');
@@ -11,10 +13,18 @@ export class KeywordTrigger implements Trigger {
       .split(/\r?\n/)
       .map((k) => k.trim().toLowerCase())
       .filter(Boolean);
+    this.stems = this.keywords.map((k) => Stemmer.stem(k));
   }
 
   matches(ctx: Context): boolean {
     const text = ((ctx.message as any)?.text ?? '').toLowerCase();
-    return this.keywords.some((k) => text.includes(k));
+    const words = text.match(/\p{L}+/gu) || [];
+    for (const word of words) {
+      const stem = Stemmer.stem(word);
+      if (this.stems.some((s) => stem.includes(s) || s.includes(stem))) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- add `natural` dependency for stemming keywords
- use Russian Porter stemmer for partial keyword matches

## Testing
- `npm exec tsc`

------
https://chatgpt.com/codex/tasks/task_e_686d726b856883278f6738ec1ce7137e