### PR TITLE
Replace stemming with simple similarity check

### DIFF
--- a/src/triggers/KeywordTrigger.ts
+++ b/src/triggers/KeywordTrigger.ts
@@ -5,6 +5,24 @@ import { Trigger } from './Trigger';
 export class KeywordTrigger implements Trigger {
   private keywords: string[];
 
+  private static similarity(a: string, b: string): number {
+    const s1 = a.toLowerCase();
+    const s2 = b.toLowerCase();
+    let max = 0;
+    for (let i = 0; i < s1.length; i++) {
+      for (let j = 0; j < s2.length; j++) {
+        let k = 0;
+        while (s1[i + k] && s2[j + k] && s1[i + k] === s2[j + k]) {
+          k++;
+        }
+        if (k > max) {
+          max = k;
+        }
+      }
+    }
+    return max / Math.max(s1.length, s2.length);
+  }
+
   constructor(filename: string) {
     const data = readFileSync(filename, 'utf-8');
     this.keywords = data
@@ -15,6 +33,14 @@ export class KeywordTrigger implements Trigger {
 
   matches(ctx: Context): boolean {
     const text = ((ctx.message as any)?.text ?? '').toLowerCase();
-    return this.keywords.some((k) => text.includes(k));
+    const words = text.match(/\p{L}+/gu) || [];
+    for (const word of words) {
+      for (const keyword of this.keywords) {
+        if (KeywordTrigger.similarity(word, keyword) >= 0.75) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- drop `natural` dependency
- implement custom word similarity function
- match keywords when word similarity exceeds 0.75

## Testing
- `npm exec tsc`


------
https://chatgpt.com/codex/tasks/task_e_686d726b856883278f6738ec1ce7137e