### PR TITLE
Refine trigger system

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ A Telegram bot named "Аркадий" written in TypeScript. It integrates OpenA
 
 ## Project structure
 
-- `src/index.ts` – bot entry point using Telegraf.
-- `src/services/ChatGPTService.ts` – wrapper around the OpenAI API.
-- `src/services/ChatMemory.ts` – manages conversation history and summaries.
-- `dist/` – compiled output after running the build.
+ - `src/index.ts` – minimal entry point that boots the application.
+ - `src/bot/TelegramBot.ts` – orchestrates Telegraf and message handling.
+ - `src/services/ChatGPTService.ts` – implementation of the `AIService` interface.
+ - `src/services/ChatMemory.ts` – manages conversation history and summaries.
+ - `dist/` – compiled output after running the build.
 
 The repository uses npm and TypeScript. Run `npm exec tsc` to ensure the
 project compiles without errors.

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -1,0 +1,83 @@
+import { Telegraf, Context } from 'telegraf';
+import { AIService } from '../services/AIService';
+import { ChatMemoryManager } from '../services/ChatMemory';
+import { DialogueManager } from '../services/DialogueManager';
+import { MentionTrigger } from '../triggers/MentionTrigger';
+import { ReplyTrigger } from '../triggers/ReplyTrigger';
+import { NameTrigger } from '../triggers/NameTrigger';
+import { KeywordTrigger } from '../triggers/KeywordTrigger';
+import { TriggerContext } from '../triggers/Trigger';
+
+export class TelegramBot {
+  private bot: Telegraf;
+  private dialogue = new DialogueManager(60 * 1000);
+  private mentionTrigger = new MentionTrigger();
+  private replyTrigger = new ReplyTrigger();
+  private nameTrigger = new NameTrigger('Карл');
+  private keywordTrigger = new KeywordTrigger('keywords.txt');
+
+  constructor(token: string, private ai: AIService, private memories: ChatMemoryManager) {
+    this.bot = new Telegraf(token);
+    this.configure();
+  }
+
+  private configure() {
+    this.bot.start((ctx) => ctx.reply('Привет! Я Карл.'));
+
+    this.bot.command('reset', async (ctx) => {
+      await this.memories.reset(ctx.chat.id);
+      ctx.reply('Контекст диалога сброшен!');
+    });
+
+    this.bot.on('text', (ctx) => this.handleText(ctx));
+  }
+
+  private async handleText(ctx: Context) {
+    const chatId = ctx.chat!.id as number;
+    const context: TriggerContext = {
+      text: (ctx.message as any).text as string,
+      replyText: '',
+      chatId,
+    };
+
+    const inDialogue = this.dialogue.isActive(chatId);
+
+    let matched = false;
+    matched = this.mentionTrigger.apply(ctx, context, this.dialogue) || matched;
+    matched = this.replyTrigger.apply(ctx, context, this.dialogue) || matched;
+    matched = this.nameTrigger.apply(ctx, context, this.dialogue) || matched;
+
+    if (!matched && !inDialogue) {
+      if (!this.keywordTrigger.apply(ctx, context, this.dialogue)) {
+        return;
+      }
+    } else if (!matched && inDialogue) {
+      this.dialogue.extend(chatId);
+    }
+
+    await ctx.sendChatAction('typing');
+
+    const memory = this.memories.get(chatId);
+
+    let userPrompt = '';
+    if (context.replyText) {
+      userPrompt += `Пользователь ответил на это сообщение: "${context.replyText}";`;
+    }
+    userPrompt += `Сообщение пользователя: "${context.text}";`;
+
+    await memory.addMessage('user', userPrompt);
+
+    const answer = await this.ai.ask(await memory.getHistory(), await memory.getSummary());
+    await memory.addMessage('assistant', answer);
+
+    ctx.reply(answer, { reply_parameters: { message_id: (ctx.message as any).message_id } });
+  }
+
+  public launch() {
+    this.bot.launch();
+  }
+
+  public stop(reason: string) {
+    this.bot.stop(reason);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,8 @@
 import 'dotenv/config';
-import { Telegraf } from 'telegraf';
 import { ChatGPTService } from './services/ChatGPTService';
 import { ChatMemoryManager } from './services/ChatMemory';
 import { SQLiteMemoryStorage } from './services/storage/SQLiteMemoryStorage';
-import { DialogueManager } from './services/DialogueManager';
-import { MentionTrigger } from './triggers/MentionTrigger';
-import { ReplyTrigger } from './triggers/ReplyTrigger';
-import { NameTrigger } from './triggers/NameTrigger';
-import { KeywordTrigger } from './triggers/KeywordTrigger';
+import { TelegramBot } from './bot/TelegramBot';
 
 const token = process.env.BOT_TOKEN;
 const apiKey = process.env.OPENAI_API_KEY;
@@ -15,82 +10,14 @@ if (!token || !apiKey) {
   throw new Error('BOT_TOKEN and OPENAI_API_KEY are required');
 }
 
-const gpt = new ChatGPTService(apiKey);
+const ai = new ChatGPTService(apiKey);
 const storage = new SQLiteMemoryStorage();
-const memories = new ChatMemoryManager(gpt, storage, 20);
-const bot = new Telegraf(token);
-const dialogue = new DialogueManager(60 * 1000);
-const mentionTrigger = new MentionTrigger();
-const replyTrigger = new ReplyTrigger();
-const nameTrigger = new NameTrigger('Карл');
-const keywordTrigger = new KeywordTrigger('keywords.txt');
+const memories = new ChatMemoryManager(ai, storage, 20);
 
-bot.start((ctx) => ctx.reply('Привет! Я Карл.'));
+const bot = new TelegramBot(token, ai, memories);
 
-bot.command('reset', async (ctx) => {
-  await memories.reset(ctx.chat.id);
-  ctx.reply('Контекст диалога сброшен!');
-});
-
-bot.on('text', async (ctx) => {
-  const isMentioned = mentionTrigger.matches(ctx);
-  const isReply = replyTrigger.matches(ctx);
-  const isNameMentioned = nameTrigger.matches(ctx);
-  const chatId = ctx.chat.id;
-  const inDialogue = dialogue.isActive(chatId);
-
-  if (!(isMentioned || isReply || isNameMentioned || inDialogue)) {
-    if (!keywordTrigger.matches(ctx)) {
-      return;
-    }
-  }
-
-  await ctx.sendChatAction('typing');
-
-  let text = ctx.message.text;
-  if (isMentioned) {
-    text = text.replace(`@${ctx.me}`, '').trim();
-  }
-  if (isNameMentioned) {
-    text = text.replace(/^Карл[,:\s]/i, '').trim();
-  }
-  let replyText = '';
-  if (
-    ctx.message.reply_to_message &&
-    // @ts-ignore
-    typeof ctx.message.reply_to_message.text === 'string'
-  ) {
-    // @ts-ignore
-    replyText = ctx.message.reply_to_message.text;
-  }
-
-  if (isMentioned || isReply || isNameMentioned) {
-    dialogue.start(chatId);
-  } else if (inDialogue) {
-    dialogue.extend(chatId);
-  }
-  const memory = memories.get(chatId);
-
-  let userPrompt = '';
-  if (replyText) {
-    userPrompt += `Пользователь ответил на это сообщение: "${replyText}";`;
-  }
-
-  userPrompt += `Сообщение пользователя: "${text}";`;
-
-  await memory.addMessage('user', userPrompt);
-
-  const answer = await gpt.ask(await memory.getHistory(), await memory.getSummary());
-  await memory.addMessage('assistant', answer);
-
-  ctx.reply(answer, { reply_parameters: { message_id: ctx.message.message_id } });
-});
-
-async function start() {
-  bot.launch();
-}
-
-start();
+bot.launch();
 
 process.once('SIGINT', () => bot.stop('SIGINT'));
 process.once('SIGTERM', () => bot.stop('SIGTERM'));
+

--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -1,0 +1,10 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AIService {
+  ask(history: ChatMessage[], summary?: string): Promise<string>;
+  summarize(history: ChatMessage[], prev?: string): Promise<string>;
+}
+

--- a/src/services/ChatGPTService.ts
+++ b/src/services/ChatGPTService.ts
@@ -1,12 +1,8 @@
 import OpenAI from 'openai';
 import { readFile } from 'fs/promises';
+import { AIService, ChatMessage } from './AIService';
 
-export interface ChatMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
-export class ChatGPTService {
+export class ChatGPTService implements AIService {
   private openai: OpenAI;
   private persona: string | null = null;
 

--- a/src/services/ChatMemory.ts
+++ b/src/services/ChatMemory.ts
@@ -1,9 +1,9 @@
-import { ChatMessage, ChatGPTService } from "./ChatGPTService";
+import { ChatMessage, AIService } from "./AIService";
 import { MemoryStorage } from "./storage/MemoryStorage.interface";
 
 export class ChatMemory {
   constructor(
-    private gpt: ChatGPTService,
+    private gpt: AIService,
     private store: MemoryStorage,
     private chatId: number,
     private limit = 10
@@ -33,7 +33,7 @@ export class ChatMemory {
 
 export class ChatMemoryManager {
   constructor(
-    private gpt: ChatGPTService,
+    private gpt: AIService,
     private store: MemoryStorage,
     private limit = 10
   ) {}

--- a/src/services/storage/SQLiteMemoryStorage.ts
+++ b/src/services/storage/SQLiteMemoryStorage.ts
@@ -1,7 +1,7 @@
 import { open, Database } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import { MemoryStorage } from './MemoryStorage.interface';
-import { ChatMessage } from '../ChatGPTService';
+import { ChatMessage } from '../AIService';
 
 export class SQLiteMemoryStorage implements MemoryStorage {
   private db: Promise<Database>;

--- a/src/triggers/KeywordTrigger.ts
+++ b/src/triggers/KeywordTrigger.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { Context } from 'telegraf';
-import { Trigger } from './Trigger';
+import { Trigger, TriggerContext } from './Trigger';
+import { DialogueManager } from '../services/DialogueManager';
 
 export class KeywordTrigger implements Trigger {
   private keywords: string[];
@@ -31,8 +32,8 @@ export class KeywordTrigger implements Trigger {
       .filter(Boolean);
   }
 
-  matches(ctx: Context): boolean {
-    const text = ((ctx.message as any)?.text ?? '').toLowerCase();
+  apply(ctx: Context, context: TriggerContext, _dialogue: DialogueManager): boolean {
+    const text = context.text.toLowerCase();
     const words = text.match(/\p{L}+/gu) || [];
     for (const word of words) {
       for (const keyword of this.keywords) {

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -1,9 +1,15 @@
 import { Context } from 'telegraf';
-import { Trigger } from './Trigger';
+import { Trigger, TriggerContext } from './Trigger';
+import { DialogueManager } from '../services/DialogueManager';
 
 export class MentionTrigger implements Trigger {
-  matches(ctx: Context): boolean {
+  apply(ctx: Context, context: TriggerContext, dialogue: DialogueManager): boolean {
     const text = (ctx.message as any)?.text ?? '';
-    return text.includes(`@${ctx.me}`);
+    if (text.includes(`@${ctx.me}`)) {
+      context.text = text.replace(`@${(ctx as any).me}`, '').trim();
+      dialogue.start(context.chatId);
+      return true;
+    }
+    return false;
   }
 }

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -1,13 +1,19 @@
 import { Context } from 'telegraf';
-import { Trigger } from './Trigger';
+import { Trigger, TriggerContext } from './Trigger';
+import { DialogueManager } from '../services/DialogueManager';
 
 export class NameTrigger implements Trigger {
   private pattern: RegExp;
   constructor(name: string) {
     this.pattern = new RegExp(`^${name}[,:\\s]`, 'i');
   }
-  matches(ctx: Context): boolean {
-    const text = (ctx.message as any)?.text ?? '';
-    return this.pattern.test(text);
+  apply(ctx: Context, context: TriggerContext, dialogue: DialogueManager): boolean {
+    const text = context.text;
+    if (this.pattern.test(text)) {
+      context.text = text.replace(this.pattern, '').trim();
+      dialogue.start(context.chatId);
+      return true;
+    }
+    return false;
   }
 }

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -1,10 +1,17 @@
 import { Context } from 'telegraf';
-import { Trigger } from './Trigger';
+import { Trigger, TriggerContext } from './Trigger';
+import { DialogueManager } from '../services/DialogueManager';
 
 export class ReplyTrigger implements Trigger {
-  matches(ctx: Context): boolean {
-    return (
-      (ctx.message as any)?.reply_to_message?.from?.username === ctx.me
-    );
+  apply(ctx: Context, context: TriggerContext, dialogue: DialogueManager): boolean {
+    const reply = (ctx.message as any)?.reply_to_message;
+    if (reply && typeof reply.text === 'string') {
+      context.replyText = reply.text;
+    }
+    if (reply?.from?.username === ctx.me) {
+      dialogue.start(context.chatId);
+      return true;
+    }
+    return false;
   }
 }

--- a/src/triggers/Trigger.ts
+++ b/src/triggers/Trigger.ts
@@ -1,5 +1,12 @@
 import { Context } from 'telegraf';
+import { DialogueManager } from '../services/DialogueManager';
+
+export interface TriggerContext {
+  text: string;
+  replyText: string;
+  chatId: number;
+}
 
 export interface Trigger {
-  matches(ctx: Context): boolean;
+  apply(ctx: Context, context: TriggerContext, dialogue: DialogueManager): boolean;
 }


### PR DESCRIPTION
## Summary
- extend `Trigger` to modify text and manage dialogue
- implement trigger logic for mention, name, reply and keyword detection
- update `TelegramBot` to use new trigger workflow

## Testing
- `npm exec tsc`


------
https://chatgpt.com/codex/tasks/task_e_686e424a89e88327b6f72ab403883132