### PR TITLE
Migrate dev runtime from ts-node to swc

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": false,
+      "decorators": false
+    },
+    "target": "es2016"
+  },
+  "module": {
+    "type": "commonjs"
+  },
+  "sourceMaps": true
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "бот Карл",
   "main": "index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "swc src -d dist --copy-files",
     "start": "node dist/index.js",
-    "dev": "nodemon --watch src --ext ts,js,json,md --exec ts-node src/index.ts",
+    "dev": "nodemon --watch src --ext ts,js,json,md --exec node -r @swc-node/register src/index.ts",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --ext .ts",
@@ -30,6 +30,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@swc/cli": "^0.7.8",
+    "@swc/core": "^1.12.11",
     "@types/node": "^24.0.11",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
@@ -41,7 +43,7 @@
     "lint-staged": "^16.1.2",
     "nodemon": "^3.1.0",
     "prettier": "^3.6.2",
-    "ts-node": "^10.9.2",
+    "@swc-node/register": "^1.10.10",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },


### PR DESCRIPTION
## Summary
- use `@swc-node/register` for development mode
- drop `ts-node` dependency

## Testing
- `npm exec tsc`
- `npm test` *(terminated after pass)*

------
https://chatgpt.com/codex/tasks/task_e_686ea9e97dbc8327bbb08a17e2e30ecf