### PR TITLE
Switch to natural stemming

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,17 +20,19 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@types/natural": "^6.0.1",
     "dotenv": "^17.1.0",
+    "natural": "^8.1.0",
     "openai": "^5.8.2",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
-    "telegraf": "^4.16.3",
-    "node-snowball": "^0.8.0"
+    "telegraf": "^4.16.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@swc-node/register": "^1.10.10",
     "@swc/cli": "^0.7.8",
     "@swc/core": "^1.12.11",
     "@types/node": "^24.0.11",
@@ -44,7 +46,6 @@
     "lint-staged": "^16.1.2",
     "nodemon": "^3.1.0",
     "prettier": "^3.6.2",
-    "@swc-node/register": "^1.10.10",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },

--- a/src/triggers/StemDictTrigger.ts
+++ b/src/triggers/StemDictTrigger.ts
@@ -1,14 +1,10 @@
 import { readFileSync } from 'fs';
-import Snowball from 'node-snowball';
+import { PorterStemmerRu } from 'natural';
 import { Context } from 'telegraf';
 
 import { DialogueManager } from '../services/DialogueManager';
 import logger from '../services/logger';
 import { Trigger, TriggerContext } from './Trigger';
-
-const stemmer = Snowball as unknown as {
-  stemword: (w: string, lang?: string) => string;
-};
 
 type Dict = Record<string, string[]>;
 
@@ -20,7 +16,7 @@ export class StemDictTrigger implements Trigger {
 
     for (const [concept, words] of Object.entries(dict)) {
       for (const w of words) {
-        const stem = stemmer.stemword(w.toLowerCase(), 'russian');
+        const stem = PorterStemmerRu.stem(w.toLowerCase());
         this.stemsToConcept.set(stem, concept);
       }
     }
@@ -37,7 +33,7 @@ export class StemDictTrigger implements Trigger {
   ): boolean {
     const tokens = text.match(/\p{L}+/gu) || [];
     for (const t of tokens) {
-      const stem = stemmer.stemword(t.toLowerCase(), 'russian');
+      const stem = PorterStemmerRu.stem(t.toLowerCase());
       const concept = this.stemsToConcept.get(stem);
       if (concept) {
         logger.debug({ chatId, concept, stem }, 'Stem trigger matched');


### PR DESCRIPTION
## Summary
- replace deprecated `node-snowball` package with `natural`
- use `PorterStemmerRu` for Russian stemming

## Testing
- `npm run build`
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877d13a81588327be3722a8c2948184