### PR TITLE
feat: run type check on pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+npm run type:check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "type:check": "tsc --noEmit",
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --check .",


### PR DESCRIPTION
## Summary
- run TypeScript type checking as part of the pre-commit hook

## Testing
- `npm run build`
- `npm test`
- `npm run test:watch -- --run`
- `npm run test:coverage`
- `npm run type:check`


------
https://chatgpt.com/codex/tasks/task_e_688f56a1b0c08327b44635f87370c6d8