### PR TITLE
Remove comments and translate logs to English

### DIFF
--- a/COMMIT_MESSAGE_RULES.md
+++ b/COMMIT_MESSAGE_RULES.md
@@ -1,0 +1,9 @@
+# Commit Message Rules
+
+- Use English language.
+- Start with an imperative verb and keep the summary under 72 characters.
+- Separate subject from body with a blank line.
+- Explain motivation and contrast with previous behavior in the body when necessary.
+- Reference issues or tickets if applicable.
+- Example:
+  - `Add database migration logging`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # --------------------------------------------------------
-# Build‑once, run‑anywhere Dockerfile for Fly.io / Node.js
+# Build-once, run-anywhere Dockerfile for Fly.io / Node.js
 # --------------------------------------------------------
-# 1)  Builds TypeScript/SWC → plain JS during image build
-# 2)  Prunes dev‑dependencies ➜ tiny production image
-# 3)  Runs pre‑compiled JS, so @swc‑node/register не нужен
+# 1) Builds TypeScript/SWC → plain JS during image build
+# 2) Prunes dev-dependencies ➜ tiny production image
+# 3) Runs pre-compiled JS, so @swc-node/register isn't needed
 # --------------------------------------------------------
 
 ARG NODE_VERSION=20.18.0
@@ -29,9 +29,9 @@ RUN npm ci --include=dev
 
 # --- copy sources & transpile to dist/
 COPY . .
-RUN npm run build   # предполагает, что output = ./dist
+RUN npm run build   # assumes output = ./dist
 
-# --- drop dev‑deps to shrink final layer
+# --- drop dev-deps to shrink final layer
 RUN npm prune --omit=dev
 
 #######################  Runtime stage  ######################
@@ -42,15 +42,15 @@ COPY --from=build /app /app
 
 # --- create entrypoint script
 RUN echo '#!/bin/sh\n\
-# Проверяем, существует ли база данных и таблица migrations\n\
+# Check if database and migrations table exist\n\
 if [ ! -f /data/memory.db ] || ! node dist/migrate.js check 2>/dev/null; then\n\
-  echo "Выполняем миграции..."\n\
+  echo "Running migrations..."\n\
   node dist/migrate.js up\n\
 else\n\
-  echo "Миграции уже выполнены, пропускаем"\n\
+  echo "Migrations already applied, skipping"\n\
 fi\n\
 \n\
-echo "Запускаем приложение..."\n\
+echo "Starting application..."\n\
 exec node dist/index.js\n\
 ' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -15,20 +15,17 @@ import { ReplyTrigger } from '../triggers/ReplyTrigger';
 import { StemDictTrigger } from '../triggers/StemDictTrigger';
 import { TriggerContext } from '../triggers/Trigger';
 
-// Хелпер-обёртка: показывает "typing…" всё время работы колбэка
 async function withTyping(ctx: Context, fn: () => Promise<void>) {
-  // запускаем индикатор сразу
   await ctx.sendChatAction('typing');
 
-  // каждые 4 с шлём ещё один, пока задача не кончится
   const timer = setInterval(() => {
     ctx.telegram.sendChatAction(ctx.chat!.id, 'typing').catch(() => {});
   }, 4000);
 
   try {
-    await fn(); // ваша долгая логика — запрос к БД, API и т.д.
+    await fn();
   } finally {
-    clearInterval(timer); // убираем таймер даже при ошибке
+    clearInterval(timer);
   }
 }
 
@@ -61,13 +58,6 @@ export class TelegramBot {
 
     this.bot.command('ping', (ctx) => ctx.reply('pong'));
 
-    // this.bot.on('message', (ctx) => {
-    //   logger.debug(
-    //     { message: ctx.message, chatId: ctx.chat?.id },
-    //     'Получено сообщение'
-    //   );
-    // });
-
     this.bot.on(message('text'), (ctx) => this.handleText(ctx));
   }
 
@@ -77,7 +67,7 @@ export class TelegramBot {
     logger.debug({ chatId }, 'Received text message');
 
     if (!this.filter.isAllowed(chatId)) {
-      logger.warn({ chatId }, 'Попытка доступа из неразрешённого чата');
+      logger.warn({ chatId }, 'Unauthorized chat access attempt');
       ctx.reply('Этот чат не находится в списке разрешённых.');
       return;
     }

--- a/src/services/logging/logger.ts
+++ b/src/services/logging/logger.ts
@@ -1,7 +1,5 @@
 import pino from 'pino';
 
-// Configure pino with asynchronous logging
-// Using pino.destination with sync:false ensures writes are non-blocking
 const destination = pino.destination({ sync: false });
 
 const logger = pino(

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,9 +1,3 @@
-/**
- * Парсит DATABASE_URL и извлекает путь к файлу базы данных
- * @param databaseUrl - URL базы данных в формате file:///path/to/database.db
- * @returns путь к файлу базы данных
- * @throws Error если DATABASE_URL не указан
- */
 export function parseDatabaseUrl(databaseUrl: string | undefined): string {
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required');

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -24,7 +24,6 @@ describe('ChatMemory', () => {
     await memory.addMessage('user', 'm1', 'u1');
     await memory.addMessage('assistant', 'm2', 'bot');
     await memory.addMessage('user', 'm3', 'u1');
-    // No summary yet
     expect(ai.summarize).not.toHaveBeenCalled();
 
     await memory.addMessage('assistant', 'm4', 'bot');


### PR DESCRIPTION
## Summary
- remove inline comments across code and configs
- translate log messages to English and clean Dockerfile output
- document commit message rules
- restore English comments in Dockerfile, tsconfig, and Fly config

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:watch` (terminated after initial run)
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_688f56ed06b8832792c6b6991b98872c