### PR TITLE
Replace swc build with Rspack for absolute path support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "бот Карл",
   "main": "index.js",
   "scripts": {
-    "build": "swc src -d dist --copy-files --strip-leading-paths",
+    "build": "rspack build",
     "start": "node dist/index.js",
     "dev": "nodemon --watch src --ext ts,js,json,md --exec node -r @swc-node/register src/index.ts",
     "test": "vitest run",
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@rspack/cli": "^1.4.11",
     "@swc-node/register": "^1.10.10",
-    "@swc/cli": "^0.7.8",
     "@swc/core": "^1.12.11",
     "@types/node": "^24.0.11",
     "@typescript-eslint/eslint-plugin": "^8.36.0",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -1,0 +1,57 @@
+/* eslint-env node */
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef */
+const path = require('node:path');
+
+/** @type {import('@rspack/cli').Configuration} */
+module.exports = {
+  target: 'node',
+  mode: 'production',
+  entry: {
+    index: './src/index.ts',
+    migrate: './src/migrate.ts',
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name].js',
+  },
+  resolve: {
+    extensions: ['.ts', '.js'],
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/, // transpile TypeScript files
+        loader: 'builtin:swc-loader',
+        options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              decorators: true,
+            },
+            transform: {
+              legacyDecorator: true,
+              decoratorMetadata: true,
+            },
+            target: 'es2016',
+          },
+          module: {
+            type: 'commonjs',
+          },
+        },
+      },
+    ],
+  },
+  externalsPresets: { node: true },
+  externalsType: 'commonjs',
+  externals: [
+    ({ request }, callback) => {
+      if (/^[a-z@][a-z0-9/._-]*$/i.test(request)) {
+        return callback(null, `commonjs ${request}`);
+      }
+      callback();
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- replace swc-based build with Rspack
- add Rspack config for Node targets and `@` path alias

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f953c6f5c8327bbbf567e9f0c31fe