### PR TITLE
Store dump requests in SQLite table

### DIFF
--- a/migrations/005_add_awaiting_export_table.down.sql
+++ b/migrations/005_add_awaiting_export_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS awaiting_export;

--- a/migrations/005_add_awaiting_export_table.up.sql
+++ b/migrations/005_add_awaiting_export_table.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS awaiting_export (
+  chat_id INTEGER PRIMARY KEY
+);


### PR DESCRIPTION
## Summary
- persist `/dump` authorization state in new `awaiting_export` table
- look up chat export requests from the database instead of memory
- add migration for `awaiting_export` table

## Testing
- `npm run build`
- `npm test`
- `DATABASE_URL=file:memory.db node dist/migrate.js up`

------
https://chatgpt.com/codex/tasks/task_e_688fa2ebfe1c8327a15fb404927f5158