### PR TITLE
Add unit test for JSONWhiteListChatFilter

### DIFF
--- a/test/ChatFilter.test.ts
+++ b/test/ChatFilter.test.ts
@@ -1,0 +1,24 @@
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { JSONWhiteListChatFilter } from '../src/services/chat/ChatFilter';
+import { TestEnvService } from '../src/services/env/EnvService';
+
+describe('JSONWhiteListChatFilter', () => {
+  it('allows only whitelisted chat IDs', () => {
+    const allowedIds = [100, 200];
+    const file = join(tmpdir(), `whitelist-${Date.now()}.json`);
+    writeFileSync(file, JSON.stringify(allowedIds), 'utf-8');
+
+    const env = new TestEnvService();
+    vi.spyOn(env, 'getWhitelistFile').mockReturnValue(file);
+
+    const filter = new JSONWhiteListChatFilter(env);
+
+    expect(filter.isAllowed(100)).toBe(true);
+    expect(filter.isAllowed(200)).toBe(true);
+    expect(filter.isAllowed(300)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for JSONWhiteListChatFilter verifying allowed IDs via temporary JSON whitelist

## Testing
- `npm run build`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689b50076b248327a6654a2ea85ab003