### PR TITLE
Add parseDatabaseUrl tests

### DIFF
--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDatabaseUrl } from '../src/utils/database';
+
+describe('parseDatabaseUrl', () => {
+  it('returns path without file:// prefix', () => {
+    expect(parseDatabaseUrl('file:///tmp/db.sqlite')).toBe('/tmp/db.sqlite');
+  });
+
+  it('throws when URL is undefined', () => {
+    expect(() => parseDatabaseUrl(undefined)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering `parseDatabaseUrl` util

## Testing
- `npm run build`
- `npm test`
- `npm run test:watch -- --run`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689b501950c48327bfb475ea49e737bb