### PR TITLE
feat: load prompts lazily

### DIFF
--- a/src/services/prompts/PromptService.ts
+++ b/src/services/prompts/PromptService.ts
@@ -1,17 +1,17 @@
 export interface PromptService {
   getPersona(): Promise<string>;
-  getPriorityRulesSystemPrompt(): string;
-  getUserPromptSystemPrompt(): string;
-  getAskSummaryPrompt(summary: string): string;
-  getSummarizationSystemPrompt(): string;
-  getPreviousSummaryPrompt(prev: string): string;
+  getPriorityRulesSystemPrompt(): Promise<string>;
+  getUserPromptSystemPrompt(): Promise<string>;
+  getAskSummaryPrompt(summary: string): Promise<string>;
+  getSummarizationSystemPrompt(): Promise<string>;
+  getPreviousSummaryPrompt(prev: string): Promise<string>;
   getUserPrompt(
     userMessage: string,
     userName?: string,
     fullName?: string,
     replyMessage?: string,
     quoteMessage?: string
-  ): string;
+  ): Promise<string>;
 }
 
 import type { ServiceIdentifier } from 'inversify';

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -1,0 +1,16 @@
+export function createLazy<T>(loader: () => Promise<T>): () => Promise<T> {
+  let cache: T | undefined;
+  let promise: Promise<T> | null = null;
+  return async () => {
+    if (cache !== undefined) {
+      return cache;
+    }
+    if (!promise) {
+      promise = loader().then((value) => {
+        cache = value;
+        return value;
+      });
+    }
+    return promise;
+  };
+}

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -69,14 +69,14 @@ describe('FilePromptService', () => {
     expect(readFileSpy).toHaveBeenCalledWith(personaPath, 'utf-8');
   });
 
-  it('getAskSummaryPrompt substitutes summary', () => {
-    expect(service.getAskSummaryPrompt('S')).toBe('ask S');
+  it('getAskSummaryPrompt substitutes summary', async () => {
+    expect(await service.getAskSummaryPrompt('S')).toBe('ask S');
   });
 
-  it('getUserPrompt substitutes values', () => {
-    const prompt = service.getUserPrompt('m', 'u', 'f', 'r', 'q');
+  it('getUserPrompt substitutes values', async () => {
+    const prompt = await service.getUserPrompt('m', 'u', 'f', 'r', 'q');
     expect(prompt).toBe('m|u|f|r|q');
-    const prompt2 = service.getUserPrompt('m');
+    const prompt2 = await service.getUserPrompt('m');
     expect(prompt2).toBe('m|N/A|N/A|N/A|N/A');
   });
 });


### PR DESCRIPTION
## Summary
- load prompt templates on demand via async lazy loaders
- update ChatGPTService for async prompt API
- add generic createLazy utility

## Testing
- `npm test`
- `npm run test:watch`
- `npm run test:coverage`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b5ac79910832787579ab9a043a585