### PR TITLE
feat: store Telegram users

### DIFF
--- a/migrations/006_create_users_table.down.sql
+++ b/migrations/006_create_users_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/migrations/006_create_users_table.up.sql
+++ b/migrations/006_create_users_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY,
+  username TEXT,
+  first_name TEXT,
+  last_name TEXT
+);

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -211,7 +211,10 @@ export class TelegramBot {
       fullName,
       replyText,
       replyUsername,
-      quoteText
+      quoteText,
+      ctx.from?.id,
+      ctx.from?.first_name,
+      ctx.from?.last_name
     );
 
     const context: TriggerContext = {

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -24,7 +24,10 @@ export class ChatMemory {
     fullName?: string,
     replyText?: string,
     replyUsername?: string,
-    quoteText?: string
+    quoteText?: string,
+    userId?: number,
+    firstName?: string,
+    lastName?: string
   ) {
     const history = await this.store.getMessages(this.chatId);
     logger.debug({ chatId: this.chatId, role }, 'Adding message');
@@ -45,7 +48,10 @@ export class ChatMemory {
       fullName,
       replyText,
       replyUsername,
-      quoteText
+      quoteText,
+      userId,
+      firstName,
+      lastName
     );
   }
 

--- a/src/services/storage/InMemoryStorage.ts
+++ b/src/services/storage/InMemoryStorage.ts
@@ -24,7 +24,10 @@ export class InMemoryStorage implements MemoryStorage {
     fullName?: string,
     replyText?: string,
     replyUsername?: string,
-    quoteText?: string
+    quoteText?: string,
+    userId?: number,
+    firstName?: string,
+    lastName?: string
   ) {
     logger.debug({ chatId, role }, 'Storing message in memory');
     const list = this.messages.get(chatId) ?? [];

--- a/src/services/storage/MemoryStorage.interface.ts
+++ b/src/services/storage/MemoryStorage.interface.ts
@@ -7,7 +7,10 @@ export interface MemoryStorage {
     fullName?: string,
     replyText?: string,
     replyUsername?: string,
-    quoteText?: string
+    quoteText?: string,
+    userId?: number,
+    firstName?: string,
+    lastName?: string
   ): Promise<void>;
   getMessages(chatId: number): Promise<
     {

--- a/src/services/storage/SQLiteMemoryStorage.ts
+++ b/src/services/storage/SQLiteMemoryStorage.ts
@@ -32,7 +32,10 @@ export class SQLiteMemoryStorage implements MemoryStorage {
     fullName?: string,
     replyText?: string,
     replyUsername?: string,
-    quoteText?: string
+    quoteText?: string,
+    userId?: number,
+    firstName?: string,
+    lastName?: string
   ) {
     logger.debug({ chatId, role }, 'Inserting message into database');
     const db = await this.getDb();
@@ -47,6 +50,16 @@ export class SQLiteMemoryStorage implements MemoryStorage {
       replyUsername ?? null,
       quoteText ?? null
     );
+
+    if (userId !== undefined) {
+      await db.run(
+        'INSERT INTO users (id, username, first_name, last_name) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET username=excluded.username, first_name=excluded.first_name, last_name=excluded.last_name',
+        userId,
+        username ?? null,
+        firstName ?? null,
+        lastName ?? null
+      );
+    }
   }
 
   async getMessages(chatId: number): Promise<ChatMessage[]> {

--- a/test/SQLiteMemoryStorage.test.ts
+++ b/test/SQLiteMemoryStorage.test.ts
@@ -29,6 +29,12 @@ beforeEach(async () => {
       reply_username TEXT,
       quote_text TEXT
     );
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      username TEXT,
+      first_name TEXT,
+      last_name TEXT
+    );
     CREATE TABLE summaries (
       chat_id INTEGER PRIMARY KEY,
       summary TEXT
@@ -68,5 +74,48 @@ describe('SQLiteMemoryStorage', () => {
     const messages = await storage.getMessages(1);
     expect(messages).toEqual([]);
     expect(await storage.getSummary(1)).toBe('');
+  });
+
+  it('stores and updates users', async () => {
+    await storage.addMessage(
+      1,
+      'user',
+      'hi',
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      42,
+      'Alice',
+      'Smith'
+    );
+    await storage.addMessage(
+      1,
+      'user',
+      'hi again',
+      'alice2',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      42,
+      'Alicia',
+      'Johnson'
+    );
+    const env = new TestEnvService();
+    const filename = parseDatabaseUrl(env.env.DATABASE_URL);
+    const db = await open({ filename, driver: sqlite3.Database });
+    const user = await db.get(
+      'SELECT id, username, first_name, last_name FROM users WHERE id = ?',
+      42
+    );
+    await db.close();
+    expect(user).toEqual({
+      id: 42,
+      username: 'alice2',
+      first_name: 'Alicia',
+      last_name: 'Johnson',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add migration for `users` table
- persist/update users when messages are stored
- record user info from incoming messages
- test user persistence and updates in SQLite storage

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b63ee97a083278be133c12affe57b