### PR TITLE
Add chats table and save titles in SQLiteMemoryStorage

### DIFF
--- a/migrations/007_create_chats_table.down.sql
+++ b/migrations/007_create_chats_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS chats;

--- a/migrations/007_create_chats_table.up.sql
+++ b/migrations/007_create_chats_table.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS chats (
+  chat_id INTEGER PRIMARY KEY,
+  title TEXT
+);

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -214,7 +214,8 @@ export class TelegramBot {
       quoteText,
       ctx.from?.id,
       ctx.from?.first_name,
-      ctx.from?.last_name
+      ctx.from?.last_name,
+      (ctx.chat as any)?.title
     );
 
     const context: TriggerContext = {
@@ -255,7 +256,19 @@ export class TelegramBot {
         await memory.getSummary()
       );
       logger.debug({ chatId }, 'Answer generated');
-      await memory.addMessage('assistant', answer, ctx.me);
+      await memory.addMessage(
+        'assistant',
+        answer,
+        ctx.me,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        (ctx.chat as any)?.title
+      );
 
       ctx.reply(answer, {
         reply_parameters: ctx.message?.message_id

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -27,7 +27,8 @@ export class ChatMemory {
     quoteText?: string,
     userId?: number,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    chatTitle?: string
   ) {
     const history = await this.store.getMessages(this.chatId);
     logger.debug({ chatId: this.chatId, role }, 'Adding message');
@@ -51,7 +52,8 @@ export class ChatMemory {
       quoteText,
       userId,
       firstName,
-      lastName
+      lastName,
+      chatTitle
     );
   }
 

--- a/src/services/storage/InMemoryStorage.ts
+++ b/src/services/storage/InMemoryStorage.ts
@@ -27,7 +27,8 @@ export class InMemoryStorage implements MemoryStorage {
     quoteText?: string,
     userId?: number,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    chatTitle?: string
   ) {
     logger.debug({ chatId, role }, 'Storing message in memory');
     const list = this.messages.get(chatId) ?? [];

--- a/src/services/storage/MemoryStorage.interface.ts
+++ b/src/services/storage/MemoryStorage.interface.ts
@@ -10,7 +10,8 @@ export interface MemoryStorage {
     quoteText?: string,
     userId?: number,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    chatTitle?: string
   ): Promise<void>;
   getMessages(chatId: number): Promise<
     {

--- a/src/services/storage/SQLiteMemoryStorage.ts
+++ b/src/services/storage/SQLiteMemoryStorage.ts
@@ -35,10 +35,16 @@ export class SQLiteMemoryStorage implements MemoryStorage {
     quoteText?: string,
     userId?: number,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    chatTitle?: string
   ) {
     logger.debug({ chatId, role }, 'Inserting message into database');
     const db = await this.getDb();
+    await db.run(
+      'INSERT INTO chats (chat_id, title) VALUES (?, ?) ON CONFLICT(chat_id) DO UPDATE SET title=excluded.title',
+      chatId,
+      chatTitle ?? null
+    );
     await db.run(
       'INSERT INTO messages (chat_id, role, content, username, full_name, reply_text, reply_username, quote_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
       chatId,

--- a/test/SQLiteMemoryStorage.test.ts
+++ b/test/SQLiteMemoryStorage.test.ts
@@ -35,6 +35,10 @@ beforeEach(async () => {
       first_name TEXT,
       last_name TEXT
     );
+    CREATE TABLE chats (
+      chat_id INTEGER PRIMARY KEY,
+      title TEXT
+    );
     CREATE TABLE summaries (
       chat_id INTEGER PRIMARY KEY,
       summary TEXT
@@ -117,5 +121,31 @@ describe('SQLiteMemoryStorage', () => {
       first_name: 'Alicia',
       last_name: 'Johnson',
     });
+  });
+
+  it('stores chats', async () => {
+    await storage.addMessage(
+      1,
+      'user',
+      'hi',
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'Test Chat'
+    );
+    const env = new TestEnvService();
+    const filename = parseDatabaseUrl(env.env.DATABASE_URL);
+    const db = await open({ filename, driver: sqlite3.Database });
+    const chat = await db.get(
+      'SELECT chat_id, title FROM chats WHERE chat_id = ?',
+      1
+    );
+    await db.close();
+    expect(chat).toEqual({ chat_id: 1, title: 'Test Chat' });
   });
 });


### PR DESCRIPTION
## Summary
- add SQL migrations for a new `chats` table
- record chat titles when saving messages to SQLite
- extend memory storage interface and cover chats table in tests

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bab87fb7483279df262c0714dafa2