### PR TITLE
Refactor messages storage to link users

### DIFF
--- a/migrations/008_alter_messages_table.down.sql
+++ b/migrations/008_alter_messages_table.down.sql
@@ -1,0 +1,44 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE messages_old (
+  chat_id INTEGER,
+  role TEXT,
+  content TEXT,
+  username TEXT,
+  reply_text TEXT,
+  reply_username TEXT,
+  full_name TEXT,
+  quote_text TEXT
+);
+
+INSERT INTO messages_old (
+  chat_id,
+  role,
+  content,
+  username,
+  reply_text,
+  reply_username,
+  full_name,
+  quote_text
+)
+SELECT
+  m.chat_id,
+  m.role,
+  m.content,
+  u.username,
+  m.reply_text,
+  m.reply_username,
+  CASE
+    WHEN u.first_name IS NOT NULL AND u.last_name IS NOT NULL THEN u.first_name || ' ' || u.last_name
+    WHEN u.first_name IS NOT NULL THEN u.first_name
+    WHEN u.last_name IS NOT NULL THEN u.last_name
+    ELSE NULL
+  END AS full_name,
+  m.quote_text
+FROM messages m
+LEFT JOIN users u ON u.id = m.user_id;
+
+DROP TABLE messages;
+ALTER TABLE messages_old RENAME TO messages;
+
+COMMIT;

--- a/migrations/008_alter_messages_table.up.sql
+++ b/migrations/008_alter_messages_table.up.sql
@@ -1,0 +1,79 @@
+BEGIN TRANSACTION;
+
+-- Ensure chats exist for foreign key constraint
+INSERT OR IGNORE INTO chats (chat_id)
+SELECT DISTINCT chat_id FROM messages;
+
+-- Prepare parsed data with separated first and last names
+WITH parsed AS (
+  SELECT
+    chat_id,
+    role,
+    content,
+    username,
+    full_name,
+    reply_text,
+    reply_username,
+    quote_text,
+    CASE
+      WHEN full_name LIKE '% %' THEN substr(full_name, 1, instr(full_name, ' ') - 1)
+      ELSE full_name
+    END AS first_name,
+    CASE
+      WHEN full_name LIKE '% %' THEN substr(full_name, instr(full_name, ' ') + 1)
+      ELSE NULL
+    END AS last_name
+  FROM messages
+)
+-- Insert users extracted from messages
+INSERT INTO users (username, first_name, last_name)
+SELECT DISTINCT username, first_name, last_name FROM parsed;
+
+-- Create new messages table
+CREATE TABLE messages_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  chat_id INTEGER NOT NULL,
+  message_id INTEGER,
+  role TEXT,
+  content TEXT,
+  user_id INTEGER NOT NULL,
+  reply_text TEXT,
+  reply_username TEXT,
+  quote_text TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (chat_id) REFERENCES chats(chat_id)
+);
+
+-- Copy data from old table to new one
+INSERT INTO messages_new (
+  chat_id,
+  message_id,
+  role,
+  content,
+  user_id,
+  reply_text,
+  reply_username,
+  quote_text
+)
+SELECT
+  p.chat_id,
+  NULL,
+  p.role,
+  p.content,
+  u.id,
+  p.reply_text,
+  p.reply_username,
+  p.quote_text
+FROM parsed p
+JOIN users u ON (
+  (p.username IS NULL AND u.username IS NULL) OR u.username = p.username
+) AND (
+  (p.first_name IS NULL AND u.first_name IS NULL) OR u.first_name = p.first_name
+) AND (
+  (p.last_name IS NULL AND u.last_name IS NULL) OR u.last_name = p.last_name
+);
+
+DROP TABLE messages;
+ALTER TABLE messages_new RENAME TO messages;
+
+COMMIT;

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -213,6 +213,7 @@ export class TelegramBot {
       replyUsername,
       quoteText,
       ctx.from?.id,
+      ctx.message?.message_id,
       ctx.from?.first_name,
       ctx.from?.last_name,
       (ctx.chat as any)?.title
@@ -260,6 +261,7 @@ export class TelegramBot {
         'assistant',
         answer,
         ctx.me,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -26,6 +26,7 @@ export class ChatMemory {
     replyUsername?: string,
     quoteText?: string,
     userId?: number,
+    messageId?: number,
     firstName?: string,
     lastName?: string,
     chatTitle?: string
@@ -51,6 +52,7 @@ export class ChatMemory {
       replyUsername,
       quoteText,
       userId,
+      messageId,
       firstName,
       lastName,
       chatTitle

--- a/src/services/storage/InMemoryStorage.ts
+++ b/src/services/storage/InMemoryStorage.ts
@@ -26,6 +26,7 @@ export class InMemoryStorage implements MemoryStorage {
     replyUsername?: string,
     quoteText?: string,
     userId?: number,
+    messageId?: number,
     firstName?: string,
     lastName?: string,
     chatTitle?: string

--- a/src/services/storage/MemoryStorage.interface.ts
+++ b/src/services/storage/MemoryStorage.interface.ts
@@ -9,6 +9,7 @@ export interface MemoryStorage {
     replyUsername?: string,
     quoteText?: string,
     userId?: number,
+    messageId?: number,
     firstName?: string,
     lastName?: string,
     chatTitle?: string

--- a/test/SQLiteMemoryStorage.test.ts
+++ b/test/SQLiteMemoryStorage.test.ts
@@ -19,38 +19,51 @@ beforeEach(async () => {
   const filename = parseDatabaseUrl(env.env.DATABASE_URL);
   const db = await open({ filename, driver: sqlite3.Database });
   await db.exec(`
-    CREATE TABLE messages (
-      chat_id INTEGER,
-      role TEXT,
-      content TEXT,
-      username TEXT,
-      full_name TEXT,
-      reply_text TEXT,
-      reply_username TEXT,
-      quote_text TEXT
-    );
-    CREATE TABLE users (
-      id INTEGER PRIMARY KEY,
-      username TEXT,
-      first_name TEXT,
-      last_name TEXT
-    );
-    CREATE TABLE chats (
-      chat_id INTEGER PRIMARY KEY,
-      title TEXT
-    );
-    CREATE TABLE summaries (
-      chat_id INTEGER PRIMARY KEY,
-      summary TEXT
-    );
-  `);
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY,
+        username TEXT,
+        first_name TEXT,
+        last_name TEXT
+      );
+      CREATE TABLE chats (
+        chat_id INTEGER PRIMARY KEY,
+        title TEXT
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        chat_id INTEGER NOT NULL,
+        message_id INTEGER,
+        role TEXT,
+        content TEXT,
+        user_id INTEGER NOT NULL,
+        reply_text TEXT,
+        reply_username TEXT,
+        quote_text TEXT,
+        FOREIGN KEY(user_id) REFERENCES users(id),
+        FOREIGN KEY(chat_id) REFERENCES chats(chat_id)
+      );
+      CREATE TABLE summaries (
+        chat_id INTEGER PRIMARY KEY,
+        summary TEXT
+      );
+    `);
   await db.close();
   storage = new SQLiteMemoryStorage(env);
 });
 
 describe('SQLiteMemoryStorage', () => {
   it('adds and retrieves messages', async () => {
-    await storage.addMessage(1, 'user', 'hi', 'alice');
+    await storage.addMessage(
+      1,
+      'user',
+      'hi',
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1
+    );
     await storage.addMessage(1, 'assistant', 'hello', 'bot');
     const messages = await storage.getMessages(1);
     expect(messages).toEqual([
@@ -91,6 +104,7 @@ describe('SQLiteMemoryStorage', () => {
       undefined,
       undefined,
       42,
+      undefined,
       'Alice',
       'Smith'
     );
@@ -104,6 +118,7 @@ describe('SQLiteMemoryStorage', () => {
       undefined,
       undefined,
       42,
+      undefined,
       'Alicia',
       'Johnson'
     );
@@ -129,6 +144,7 @@ describe('SQLiteMemoryStorage', () => {
       'user',
       'hi',
       'alice',
+      undefined,
       undefined,
       undefined,
       undefined,


### PR DESCRIPTION
## Summary
- migrate messages table to use numeric IDs and user references
- support userId and messageId in memory storage implementations
- pass Telegram user and message IDs when recording chat history

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689baeca56b0832784fb780f0c34e4d2