### PR TITLE
Add user and message metadata to chat history storage

### DIFF
--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -6,6 +6,9 @@ export interface ChatMessage {
   replyText?: string;
   replyUsername?: string;
   quoteText?: string;
+  userId?: number;
+  messageId?: number;
+  chatId?: number;
 }
 
 export interface AIService {

--- a/src/services/storage/InMemoryStorage.ts
+++ b/src/services/storage/InMemoryStorage.ts
@@ -1,19 +1,9 @@
+import { ChatMessage } from '../ai/AIService';
 import logger from '../logging/logger';
 import { MemoryStorage } from './MemoryStorage.interface';
 
 export class InMemoryStorage implements MemoryStorage {
-  private messages = new Map<
-    number,
-    {
-      role: 'user' | 'assistant';
-      content: string;
-      username?: string;
-      fullName?: string;
-      replyText?: string;
-      replyUsername?: string;
-      quoteText?: string;
-    }[]
-  >();
+  private messages = new Map<number, ChatMessage[]>();
   private summaries = new Map<number, string>();
 
   async addMessage(
@@ -33,20 +23,14 @@ export class InMemoryStorage implements MemoryStorage {
   ) {
     logger.debug({ chatId, role }, 'Storing message in memory');
     const list = this.messages.get(chatId) ?? [];
-    const entry: {
-      role: 'user' | 'assistant';
-      content: string;
-      username?: string;
-      fullName?: string;
-      replyText?: string;
-      replyUsername?: string;
-      quoteText?: string;
-    } = { role, content };
+    const entry: ChatMessage = { role, content, chatId };
     if (username) entry.username = username;
     if (fullName) entry.fullName = fullName;
     if (replyText) entry.replyText = replyText;
     if (replyUsername) entry.replyUsername = replyUsername;
     if (quoteText) entry.quoteText = quoteText;
+    if (userId !== undefined) entry.userId = userId;
+    if (messageId !== undefined) entry.messageId = messageId;
     list.push(entry);
     this.messages.set(chatId, list);
   }

--- a/src/services/storage/MemoryStorage.interface.ts
+++ b/src/services/storage/MemoryStorage.interface.ts
@@ -14,17 +14,7 @@ export interface MemoryStorage {
     lastName?: string,
     chatTitle?: string
   ): Promise<void>;
-  getMessages(chatId: number): Promise<
-    {
-      role: 'user' | 'assistant';
-      content: string;
-      username?: string;
-      fullName?: string;
-      replyText?: string;
-      replyUsername?: string;
-      quoteText?: string;
-    }[]
-  >;
+  getMessages(chatId: number): Promise<ChatMessage[]>;
   clearMessages(chatId: number): Promise<void>;
   getSummary(chatId: number): Promise<string>;
   setSummary(chatId: number, summary: string): Promise<void>;
@@ -32,6 +22,8 @@ export interface MemoryStorage {
 }
 
 import type { ServiceIdentifier } from 'inversify';
+
+import { ChatMessage } from '../ai/AIService';
 
 export const MEMORY_STORAGE_ID = Symbol.for(
   'MemoryStorage'

--- a/src/services/storage/SQLiteMemoryStorage.ts
+++ b/src/services/storage/SQLiteMemoryStorage.ts
@@ -80,9 +80,12 @@ export class SQLiteMemoryStorage implements MemoryStorage {
         reply_text: string | null;
         reply_username: string | null;
         quote_text: string | null;
+        user_id: number | null;
+        chat_id: number | null;
+        message_id: number | null;
       }[]
     >(
-      'SELECT m.role, m.content, u.username, u.first_name, u.last_name, m.reply_text, m.reply_username, m.quote_text FROM messages m LEFT JOIN users u ON m.user_id = u.id WHERE m.chat_id = ? ORDER BY m.id',
+      'SELECT m.role, m.content, u.username, u.first_name, u.last_name, m.reply_text, m.reply_username, m.quote_text, m.user_id, c.chat_id, m.message_id FROM messages m LEFT JOIN users u ON m.user_id = u.id LEFT JOIN chats c ON m.chat_id = c.chat_id WHERE m.chat_id = ? ORDER BY m.id',
       chatId
     );
     return (
@@ -90,6 +93,7 @@ export class SQLiteMemoryStorage implements MemoryStorage {
         const entry: ChatMessage = {
           role: r.role,
           content: r.content,
+          chatId: r.chat_id ?? undefined,
         };
         if (r.username) entry.username = r.username;
         const fullName = [r.first_name, r.last_name].filter(Boolean).join(' ');
@@ -97,6 +101,8 @@ export class SQLiteMemoryStorage implements MemoryStorage {
         if (r.reply_text) entry.replyText = r.reply_text;
         if (r.reply_username) entry.replyUsername = r.reply_username;
         if (r.quote_text) entry.quoteText = r.quote_text;
+        if (r.user_id) entry.userId = r.user_id;
+        if (r.message_id) entry.messageId = r.message_id;
         return entry;
       }) ?? []
     );

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -31,7 +31,32 @@ describe('ChatMemory', () => {
     expect(await memory.getSummary()).toBe('summary');
     const hist = await memory.getHistory();
     expect(hist).toEqual([
-      { role: 'assistant', content: 'm4', username: 'bot' },
+      { role: 'assistant', content: 'm4', username: 'bot', chatId: 1 },
+    ]);
+  });
+
+  it('stores user and message ids', async () => {
+    await memory.addMessage(
+      'user',
+      'hello',
+      'alice',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      7,
+      42
+    );
+    const hist = await memory.getHistory();
+    expect(hist).toEqual([
+      {
+        role: 'user',
+        content: 'hello',
+        username: 'alice',
+        userId: 7,
+        messageId: 42,
+        chatId: 1,
+      },
     ]);
   });
 });

--- a/test/SQLiteMemoryStorage.test.ts
+++ b/test/SQLiteMemoryStorage.test.ts
@@ -62,13 +62,24 @@ describe('SQLiteMemoryStorage', () => {
       undefined,
       undefined,
       undefined,
-      1
+      1,
+      11,
+      'Alice',
+      'Smith'
     );
     await storage.addMessage(1, 'assistant', 'hello', 'bot');
     const messages = await storage.getMessages(1);
     expect(messages).toEqual([
-      { role: 'user', content: 'hi', username: 'alice' },
-      { role: 'assistant', content: 'hello', username: 'bot' },
+      {
+        role: 'user',
+        content: 'hi',
+        username: 'alice',
+        fullName: 'Alice Smith',
+        userId: 1,
+        messageId: 11,
+        chatId: 1,
+      },
+      { role: 'assistant', content: 'hello', username: 'bot', chatId: 1 },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- extend ChatMessage model to include user, message, and chat IDs
- join users and chats in SQLiteMemoryStorage to return enriched ChatMessage objects
- update in-memory storage and ChatMemory tests for new message structure

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb192959883279b6a0ba914a737c1