### PR TITLE
refactor: use StoredMessage object for message handling

### DIFF
--- a/src/repositories/interfaces/MessageRepository.ts
+++ b/src/repositories/interfaces/MessageRepository.ts
@@ -1,20 +1,10 @@
 import type { ServiceIdentifier } from 'inversify';
 
 import type { ChatMessage } from '../../services/ai/AIService';
-
-export interface MessageEntity {
-  chatId: number;
-  messageId?: number | null;
-  role: 'user' | 'assistant';
-  content: string;
-  userId: number;
-  replyText?: string | null;
-  replyUsername?: string | null;
-  quoteText?: string | null;
-}
+import type { StoredMessage } from '../../services/messages/StoredMessage';
 
 export interface MessageRepository {
-  insert(message: MessageEntity): Promise<void>;
+  insert(message: StoredMessage): Promise<void>;
   findByChatId(chatId: number): Promise<ChatMessage[]>;
   clearByChatId(chatId: number): Promise<void>;
 }

--- a/src/repositories/sqlite/SQLiteMessageRepository.ts
+++ b/src/repositories/sqlite/SQLiteMessageRepository.ts
@@ -1,11 +1,9 @@
 import { inject, injectable } from 'inversify';
 
 import type { ChatMessage } from '../../services/ai/AIService';
+import type { StoredMessage } from '../../services/messages/StoredMessage';
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
-import {
-  type MessageEntity,
-  type MessageRepository,
-} from '../interfaces/MessageRepository';
+import { type MessageRepository } from '../interfaces/MessageRepository';
 
 @injectable()
 export class SQLiteMessageRepository implements MessageRepository {
@@ -24,7 +22,7 @@ export class SQLiteMessageRepository implements MessageRepository {
     replyText,
     replyUsername,
     quoteText,
-  }: MessageEntity): Promise<void> {
+  }: StoredMessage): Promise<void> {
     const db = await this.db();
     await db.run(
       'INSERT INTO messages (chat_id, message_id, role, content, user_id, reply_text, reply_username, quote_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
@@ -32,7 +30,7 @@ export class SQLiteMessageRepository implements MessageRepository {
       messageId ?? null,
       role,
       content,
-      userId,
+      userId ?? 0,
       replyText ?? null,
       replyUsername ?? null,
       quoteText ?? null

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -7,6 +7,7 @@ import {
   MESSAGE_SERVICE_ID,
   type MessageService,
 } from '../messages/MessageService';
+import { StoredMessage } from '../messages/StoredMessage';
 import {
   SUMMARY_SERVICE_ID,
   type SummaryService,
@@ -26,22 +27,9 @@ export class ChatMemory {
     private limit: number
   ) {}
 
-  public async addMessage(
-    role: 'user' | 'assistant',
-    content: string,
-    username?: string,
-    fullName?: string,
-    replyText?: string,
-    replyUsername?: string,
-    quoteText?: string,
-    userId?: number,
-    messageId?: number,
-    firstName?: string,
-    lastName?: string,
-    chatTitle?: string
-  ) {
+  public async addMessage(message: StoredMessage) {
     const history = await this.messages.getMessages(this.chatId);
-    logger.debug({ chatId: this.chatId, role }, 'Adding message');
+    logger.debug({ chatId: this.chatId, role: message.role }, 'Adding message');
 
     if (history.length > this.limit) {
       logger.debug({ chatId: this.chatId }, 'Summarizing chat history');
@@ -51,21 +39,7 @@ export class ChatMemory {
       await this.messages.clearMessages(this.chatId);
     }
 
-    await this.messages.addMessage(
-      this.chatId,
-      role,
-      content,
-      username,
-      fullName,
-      replyText,
-      replyUsername,
-      quoteText,
-      userId,
-      messageId,
-      firstName,
-      lastName,
-      chatTitle
-    );
+    await this.messages.addMessage({ ...message, chatId: this.chatId });
   }
 
   public getHistory(): Promise<ChatMessage[]> {

--- a/src/services/messages/MessageFactory.ts
+++ b/src/services/messages/MessageFactory.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert';
+
+import { Context } from 'telegraf';
+
+import { StoredMessage } from './StoredMessage';
+
+export class MessageFactory {
+  static fromUser(ctx: Context): StoredMessage {
+    const message = ctx.message as any;
+    assert(message && typeof message.text === 'string', 'Нет текста сообщения');
+
+    let replyText: string | undefined;
+    let replyUsername: string | undefined;
+    let quoteText: string | undefined;
+    if (message.reply_to_message) {
+      const pieces: string[] = [];
+      if (typeof message.reply_to_message.text === 'string') {
+        pieces.push(message.reply_to_message.text);
+      }
+      if (typeof message.reply_to_message.caption === 'string') {
+        pieces.push(message.reply_to_message.caption);
+      }
+      assert(pieces.length > 0, 'Нет текста или подписи в reply_to_message');
+      replyText = pieces.join('; ');
+
+      const from = message.reply_to_message.from;
+      if (from) {
+        if (from.first_name && from.last_name) {
+          replyUsername = from.first_name + ' ' + from.last_name;
+        } else {
+          replyUsername = from.first_name || from.username || undefined;
+        }
+      }
+    }
+
+    if (message.quote && typeof message.quote.text === 'string') {
+      quoteText = message.quote.text;
+    }
+
+    const username = ctx.from?.username || 'Имя неизвестно';
+    const fullName =
+      ctx.from?.first_name && ctx.from?.last_name
+        ? ctx.from.first_name + ' ' + ctx.from.last_name
+        : ctx.from?.first_name || ctx.from?.last_name || username;
+
+    return {
+      role: 'user',
+      content: message.text,
+      username,
+      fullName,
+      replyText,
+      replyUsername,
+      quoteText,
+      userId: ctx.from?.id,
+      messageId: ctx.message?.message_id,
+      firstName: ctx.from?.first_name,
+      lastName: ctx.from?.last_name,
+      chatId: ctx.chat!.id,
+      chatTitle: (ctx.chat as any)?.title,
+    };
+  }
+
+  static fromAssistant(ctx: Context, content: string): StoredMessage {
+    return {
+      role: 'assistant',
+      content,
+      username: ctx.me,
+      chatId: ctx.chat!.id,
+      chatTitle: (ctx.chat as any)?.title,
+    };
+  }
+}

--- a/src/services/messages/MessageService.ts
+++ b/src/services/messages/MessageService.ts
@@ -1,23 +1,10 @@
 import type { ServiceIdentifier } from 'inversify';
 
 import { ChatMessage } from '../ai/AIService';
+import { StoredMessage } from './StoredMessage';
 
 export interface MessageService {
-  addMessage(
-    chatId: number,
-    role: 'user' | 'assistant',
-    content: string,
-    username?: string,
-    fullName?: string,
-    replyText?: string,
-    replyUsername?: string,
-    quoteText?: string,
-    userId?: number,
-    messageId?: number,
-    firstName?: string,
-    lastName?: string,
-    chatTitle?: string
-  ): Promise<void>;
+  addMessage(message: StoredMessage): Promise<void>;
   getMessages(chatId: number): Promise<ChatMessage[]>;
   clearMessages(chatId: number): Promise<void>;
 }

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -14,6 +14,7 @@ import {
 } from '../../repositories/interfaces/UserRepository';
 import { logger } from '../logging/logger';
 import { MessageService } from './MessageService';
+import { StoredMessage } from './StoredMessage';
 
 @injectable()
 export class RepositoryMessageService implements MessageService {
@@ -23,39 +24,25 @@ export class RepositoryMessageService implements MessageService {
     @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository
   ) {}
 
-  async addMessage(
-    chatId: number,
-    role: 'user' | 'assistant',
-    content: string,
-    username?: string,
-    fullName?: string,
-    replyText?: string,
-    replyUsername?: string,
-    quoteText?: string,
-    userId?: number,
-    messageId?: number,
-    firstName?: string,
-    lastName?: string,
-    chatTitle?: string
-  ) {
-    logger.debug({ chatId, role }, 'Inserting message into database');
-    const storedUserId = userId ?? 0;
-    await this.chatRepo.upsert({ chatId, title: chatTitle ?? null });
+  async addMessage(message: StoredMessage) {
+    logger.debug(
+      { chatId: message.chatId, role: message.role },
+      'Inserting message into database'
+    );
+    const storedUserId = message.userId ?? 0;
+    await this.chatRepo.upsert({
+      chatId: message.chatId,
+      title: message.chatTitle ?? null,
+    });
     await this.userRepo.upsert({
       id: storedUserId,
-      username: username ?? null,
-      firstName: firstName ?? null,
-      lastName: lastName ?? null,
+      username: message.username ?? null,
+      firstName: message.firstName ?? null,
+      lastName: message.lastName ?? null,
     });
     await this.messageRepo.insert({
-      chatId,
-      messageId: messageId ?? null,
-      role,
-      content,
+      ...message,
       userId: storedUserId,
-      replyText: replyText ?? null,
-      replyUsername: replyUsername ?? null,
-      quoteText: quoteText ?? null,
     });
   }
 

--- a/src/services/messages/StoredMessage.ts
+++ b/src/services/messages/StoredMessage.ts
@@ -1,0 +1,9 @@
+import { ChatMessage } from '../ai/AIService';
+
+export interface StoredMessage extends ChatMessage {
+  chatId: number;
+  messageId?: number;
+  firstName?: string;
+  lastName?: string;
+  chatTitle?: string;
+}


### PR DESCRIPTION
## Summary
- add `StoredMessage` type and MessageFactory to build it from Telegram context
- update message services and repositories to accept a single `StoredMessage`
- simplify TelegramBot `handleText` by delegating message parsing to factory

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc11dffac83279b8ef15d8f1b063c