### PR TITLE
Refactor admin service to use access key repository

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -18,7 +18,7 @@ import { SQLiteMessageRepository } from './repositories/sqlite/SQLiteMessageRepo
 import { SQLiteSummaryRepository } from './repositories/sqlite/SQLiteSummaryRepository';
 import { SQLiteUserRepository } from './repositories/sqlite/SQLiteUserRepository';
 import { ADMIN_SERVICE_ID } from './services/admin/AdminService';
-import { SQLiteAdminService } from './services/admin/SQLiteAdminService';
+import { AdminServiceImpl } from './services/admin/AdminServiceImpl';
 import { AI_SERVICE_ID } from './services/ai/AIService';
 import { ChatGPTService } from './services/ai/ChatGPTService';
 import {
@@ -92,7 +92,7 @@ container
   .to(DefaultChatResetService)
   .inSingletonScope();
 
-container.bind(ADMIN_SERVICE_ID).to(SQLiteAdminService).inSingletonScope();
+container.bind(ADMIN_SERVICE_ID).to(AdminServiceImpl).inSingletonScope();
 
 container.bind(DB_PROVIDER_ID).to(SQLiteDbProviderImpl).inSingletonScope();
 container.bind(CHAT_REPOSITORY_ID).to(SQLiteChatRepository).inSingletonScope();

--- a/src/repositories/interfaces/AccessKeyRepository.ts
+++ b/src/repositories/interfaces/AccessKeyRepository.ts
@@ -8,9 +8,12 @@ export interface AccessKeyEntity {
 }
 
 export interface AccessKeyRepository {
-  upsert(entry: AccessKeyEntity): Promise<void>;
-  find(chatId: number, userId: number): Promise<AccessKeyEntity | undefined>;
-  delete(chatId: number, userId: number): Promise<void>;
+  upsertKey(entry: AccessKeyEntity): Promise<void>;
+  findByChatAndUser(
+    chatId: number,
+    userId: number
+  ): Promise<AccessKeyEntity | undefined>;
+  deleteExpired(now: number): Promise<void>;
 }
 
 export const ACCESS_KEY_REPOSITORY_ID = Symbol.for(

--- a/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
+++ b/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
@@ -14,7 +14,7 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
     return this.dbProvider.get();
   }
 
-  async upsert({
+  async upsertKey({
     chatId,
     userId,
     accessKey,
@@ -30,7 +30,7 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
     );
   }
 
-  async find(
+  async findByChatAndUser(
     chatId: number,
     userId: number
   ): Promise<AccessKeyEntity | undefined> {
@@ -55,12 +55,8 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
       : undefined;
   }
 
-  async delete(chatId: number, userId: number): Promise<void> {
+  async deleteExpired(now: number): Promise<void> {
     const db = await this.db();
-    await db.run(
-      'DELETE FROM access_keys WHERE chat_id = ? AND user_id = ?',
-      chatId,
-      userId
-    );
+    await db.run('DELETE FROM access_keys WHERE expires_at <= ?', now);
   }
 }

--- a/test/sqliteRepositories.test.ts
+++ b/test/sqliteRepositories.test.ts
@@ -174,22 +174,26 @@ describe('SQLite repositories', () => {
     expect(chat).toEqual({ chatId: 1, title: 'Test Chat' });
   });
 
-  it('stores and retrieves access keys', async () => {
-    const expiresAt = Date.now() + 1000;
-    await accessKeyRepo.upsert({
+  it('stores, retrieves and expires access keys', async () => {
+    const now = Date.now();
+    const expiresAt = now + 1000;
+    await accessKeyRepo.upsertKey({
       chatId: 1,
       userId: 2,
       accessKey: 'key',
       expiresAt,
     });
-    const entry = await accessKeyRepo.find(1, 2);
+    let entry = await accessKeyRepo.findByChatAndUser(1, 2);
     expect(entry).toEqual({
       chatId: 1,
       userId: 2,
       accessKey: 'key',
       expiresAt,
     });
-    await accessKeyRepo.delete(1, 2);
-    expect(await accessKeyRepo.find(1, 2)).toBeUndefined();
+    await accessKeyRepo.deleteExpired(now);
+    entry = await accessKeyRepo.findByChatAndUser(1, 2);
+    expect(entry).toBeTruthy();
+    await accessKeyRepo.deleteExpired(expiresAt + 1);
+    expect(await accessKeyRepo.findByChatAndUser(1, 2)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- refactor access key repository interface and SQLite implementation
- introduce AdminServiceImpl using repository without raw SQL for access keys
- adjust container bindings and tests for new API

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689bc66cbe1c8327859405a0200a264d