### PR TITLE
Switch bot to long polling and keep Fly machine awake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
 BOT_TOKEN=***
 OPENAI_API_KEY=***
-DOMAIN=***
-PORT=***
 NODE_ENV=development
 DATABASE_URL=file:///data/memory.db
 LOG_PROMPTS=false

--- a/fly.toml
+++ b/fly.toml
@@ -14,9 +14,9 @@ destination = "/data"
 
 [http_service]
 internal_port = 3000
-auto_stop_machines = "suspend"
+auto_stop_machines = "off"
 auto_start_machines = true
-min_machines_running = 0
+min_machines_running = 1
 processes = ["app"]
 
 [[vm]]

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -205,16 +205,12 @@ export class TelegramBot {
 
   public async launch() {
     logger.info('Launching bot');
-    if (this.env.NODE_ENV === 'production') {
-      await this.bot.launch({
-        webhook: {
-          domain: this.env.DOMAIN!,
-          port: this.env.PORT!,
-        },
-      });
-    } else {
-      await this.bot.launch();
-    }
+    await this.bot.telegram
+      .deleteWebhook()
+      .catch((err) =>
+        logger.warn({ err }, 'Failed to delete existing webhook')
+      );
+    await this.bot.launch();
     logger.info('Bot launched');
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import http from 'node:http';
+
 import { TelegramBot } from './bot/TelegramBot';
 import { container } from './container';
 import { logger } from './services/logging/logger';
@@ -6,6 +8,13 @@ const bot = container.get<TelegramBot>(TelegramBot);
 
 logger.info('Starting application');
 bot.launch();
+
+http
+  .createServer((_, res) => {
+    res.writeHead(200);
+    res.end('ok');
+  })
+  .listen(3000, () => logger.info('HTTP server listening on port 3000'));
 
 process.once('SIGINT', () => {
   logger.info('SIGINT received');

--- a/src/services/env/EnvService.ts
+++ b/src/services/env/EnvService.ts
@@ -5,37 +5,16 @@ import { injectable } from 'inversify';
 import { ChatModel } from 'openai/resources/shared';
 import { z } from 'zod';
 
-const envSchema = z
-  .object({
-    BOT_TOKEN: z.string().min(1),
-    OPENAI_API_KEY: z.string().min(1),
-    DATABASE_URL: z.string().min(1),
-    CHAT_HISTORY_LIMIT: z.coerce.number().int().positive().default(50),
-    LOG_LEVEL: z.string().default('debug'),
-    ADMIN_CHAT_ID: z.coerce.number(),
-    NODE_ENV: z.string().default('development'),
-    DOMAIN: z.string().optional(),
-    PORT: z.coerce.number().optional(),
-    LOG_PROMPTS: z.coerce.boolean().default(false),
-  })
-  .superRefine((data, ctx) => {
-    if (data.NODE_ENV === 'production') {
-      if (!data.DOMAIN) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['DOMAIN'],
-          message: 'DOMAIN is required in production',
-        });
-      }
-      if (data.PORT === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['PORT'],
-          message: 'PORT is required in production',
-        });
-      }
-    }
-  });
+const envSchema = z.object({
+  BOT_TOKEN: z.string().min(1),
+  OPENAI_API_KEY: z.string().min(1),
+  DATABASE_URL: z.string().min(1),
+  CHAT_HISTORY_LIMIT: z.coerce.number().int().positive().default(50),
+  LOG_LEVEL: z.string().default('debug'),
+  ADMIN_CHAT_ID: z.coerce.number(),
+  NODE_ENV: z.string().default('development'),
+  LOG_PROMPTS: z.coerce.boolean().default(false),
+});
 
 export type Env = z.infer<typeof envSchema>;
 
@@ -121,8 +100,6 @@ export class TestEnvService implements EnvService {
       ADMIN_CHAT_ID: process.env.ADMIN_CHAT_ID ?? '0',
       NODE_ENV: 'test',
       LOG_PROMPTS: process.env.LOG_PROMPTS ?? 'false',
-      DOMAIN: process.env.DOMAIN,
-      PORT: process.env.PORT,
     });
   }
 


### PR DESCRIPTION
## Summary
- remove webhook-based launch and use long polling
- keep bot process alive with a tiny HTTP server
- disable Fly machine autostop and drop DOMAIN/PORT env vars

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:watch` *(fails: requires interactive terminal)*
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689bd0c5671c8327a7d15a30cdbfd087