### PR TITLE
feat(messages): add message count and last retrieval

### DIFF
--- a/src/repositories/interfaces/MessageRepository.ts
+++ b/src/repositories/interfaces/MessageRepository.ts
@@ -6,6 +6,8 @@ import type { StoredMessage } from '../../services/messages/StoredMessage';
 export interface MessageRepository {
   insert(message: StoredMessage): Promise<void>;
   findByChatId(chatId: number): Promise<ChatMessage[]>;
+  countByChatId(chatId: number): Promise<number>;
+  findLastByChatId(chatId: number, limit: number): Promise<ChatMessage[]>;
   clearByChatId(chatId: number): Promise<void>;
 }
 

--- a/src/repositories/sqlite/SQLiteMessageRepository.ts
+++ b/src/repositories/sqlite/SQLiteMessageRepository.ts
@@ -77,6 +77,59 @@ export class SQLiteMessageRepository implements MessageRepository {
     );
   }
 
+  async countByChatId(chatId: number): Promise<number> {
+    const db = await this.db();
+    const row = await db.get<{ count: number }>(
+      'SELECT COUNT(*) as count FROM messages WHERE chat_id = ?',
+      chatId
+    );
+    return row?.count ?? 0;
+  }
+
+  async findLastByChatId(
+    chatId: number,
+    limit: number
+  ): Promise<ChatMessage[]> {
+    const db = await this.db();
+    const rows = await db.all<
+      {
+        role: 'user' | 'assistant';
+        content: string;
+        username: string | null;
+        first_name: string | null;
+        last_name: string | null;
+        reply_text: string | null;
+        reply_username: string | null;
+        quote_text: string | null;
+        user_id: number | null;
+        chat_id: number | null;
+        message_id: number | null;
+      }[]
+    >(
+      'SELECT m.role, m.content, u.username, u.first_name, u.last_name, m.reply_text, m.reply_username, m.quote_text, m.user_id, c.chat_id, m.message_id FROM messages m LEFT JOIN users u ON m.user_id = u.id LEFT JOIN chats c ON m.chat_id = c.chat_id WHERE m.chat_id = ? ORDER BY m.id DESC LIMIT ?',
+      chatId,
+      limit
+    );
+    return (
+      rows?.map((r) => {
+        const entry: ChatMessage = {
+          role: r.role,
+          content: r.content,
+          chatId: r.chat_id ?? undefined,
+        };
+        if (r.username) entry.username = r.username;
+        const fullName = [r.first_name, r.last_name].filter(Boolean).join(' ');
+        if (fullName) entry.fullName = fullName;
+        if (r.reply_text) entry.replyText = r.reply_text;
+        if (r.reply_username) entry.replyUsername = r.reply_username;
+        if (r.quote_text) entry.quoteText = r.quote_text;
+        if (r.user_id) entry.userId = r.user_id;
+        if (r.message_id) entry.messageId = r.message_id;
+        return entry;
+      }) ?? []
+    );
+  }
+
   async clearByChatId(chatId: number): Promise<void> {
     const db = await this.db();
     await db.run('DELETE FROM messages WHERE chat_id = ?', chatId);

--- a/src/services/messages/MessageService.ts
+++ b/src/services/messages/MessageService.ts
@@ -6,6 +6,8 @@ import { StoredMessage } from './StoredMessage';
 export interface MessageService {
   addMessage(message: StoredMessage): Promise<void>;
   getMessages(chatId: number): Promise<ChatMessage[]>;
+  getCount(chatId: number): Promise<number>;
+  getLastMessages(chatId: number, limit: number): Promise<ChatMessage[]>;
   clearMessages(chatId: number): Promise<void>;
 }
 

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -51,6 +51,16 @@ export class RepositoryMessageService implements MessageService {
     return this.messageRepo.findByChatId(chatId);
   }
 
+  async getCount(chatId: number) {
+    logger.debug({ chatId }, 'Counting messages in database');
+    return this.messageRepo.countByChatId(chatId);
+  }
+
+  async getLastMessages(chatId: number, limit: number) {
+    logger.debug({ chatId, limit }, 'Fetching last messages from database');
+    return this.messageRepo.findLastByChatId(chatId, limit);
+  }
+
   async clearMessages(chatId: number) {
     logger.debug({ chatId }, 'Clearing messages table');
     await this.messageRepo.clearByChatId(chatId);

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -36,6 +36,18 @@ class FakeMessageService implements MessageService {
     return list.map((m) => ({ ...m }));
   }
 
+  async getCount(chatId: number) {
+    return (this.data.get(chatId) ?? []).length;
+  }
+
+  async getLastMessages(chatId: number, limit: number) {
+    const list = this.data.get(chatId) ?? [];
+    return list
+      .slice(-limit)
+      .reverse()
+      .map((m) => ({ ...m }));
+  }
+
   async clearMessages(chatId: number) {
     this.data.set(chatId, []);
   }

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -26,8 +26,14 @@ class MockMessageService implements MessageService {
   async addMessage(msg: any): Promise<void> {
     this.messages.push(msg);
   }
-  async getMessages(): Promise<ChatMessage[]> {
+  async getMessages(_chatId: number): Promise<ChatMessage[]> {
     return [...this.messages];
+  }
+  async getCount(): Promise<number> {
+    return this.messages.length;
+  }
+  async getLastMessages(_: number, limit: number): Promise<ChatMessage[]> {
+    return [...this.messages].slice(-limit).reverse();
   }
   async clearMessages(): Promise<void> {
     this.messages = [];

--- a/test/sqliteRepositories.test.ts
+++ b/test/sqliteRepositories.test.ts
@@ -110,6 +110,29 @@ describe('SQLite repositories', () => {
     ]);
   });
 
+  it('counts and retrieves last messages', async () => {
+    await chatRepo.upsert({ chatId: 1 });
+    await userRepo.upsert({ id: 1, username: 'alice' });
+    await messageRepo.insert({
+      chatId: 1,
+      role: 'user',
+      content: 'hi',
+      userId: 1,
+    });
+    await userRepo.upsert({ id: 0, username: 'bot' });
+    await messageRepo.insert({
+      chatId: 1,
+      role: 'assistant',
+      content: 'hello',
+      userId: 0,
+    });
+    expect(await messageRepo.countByChatId(1)).toBe(2);
+    const last = await messageRepo.findLastByChatId(1, 1);
+    expect(last).toEqual([
+      { role: 'assistant', content: 'hello', username: 'bot', chatId: 1 },
+    ]);
+  });
+
   it('clears messages', async () => {
     await chatRepo.upsert({ chatId: 1 });
     await userRepo.upsert({ id: 1, username: 'alice' });


### PR DESCRIPTION
## Summary
- add count and last query methods to MessageRepository
- expose getCount and getLastMessages via MessageService
- test SQLite implementations for counting and retrieving last messages

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:watch -- --run`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c59e8b4288327a4e503274a55e2d9