### PR TITLE
feat(ai): add interest check

### DIFF
--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -14,6 +14,10 @@ export interface ChatMessage {
 export interface AIService {
   ask(history: ChatMessage[], summary?: string): Promise<string>;
   summarize(history: ChatMessage[], prev?: string): Promise<string>;
+  checkInterest(
+    history: ChatMessage[],
+    summary: string
+  ): Promise<{ messageId: string; why: string } | null>;
 }
 
 import type { ServiceIdentifier } from 'inversify';

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -19,6 +19,9 @@ class MockAIService {
   async summarize(): Promise<string> {
     return '';
   }
+  async checkInterest(): Promise<{ messageId: string; why: string } | null> {
+    return null;
+  }
 }
 
 class MockMessageService implements MessageService {


### PR DESCRIPTION
## Summary
- extend AIService with checkInterest method returning detailed interest result
- implement interest check in ChatGPTService using persona and interest prompt
- stub AI checkInterest in ChatResponder tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689c5ebbb210832787090f2e3506f5c6