### PR TITLE
Inject interest checker into TelegramBot

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -16,6 +16,10 @@ import {
   TriggerPipeline,
 } from '../services/chat/TriggerPipeline';
 import { Env, ENV_SERVICE_ID, EnvService } from '../services/env/EnvService';
+import {
+  INTEREST_CHECKER_ID,
+  InterestChecker,
+} from '../services/interest/InterestChecker';
 import { logger } from '../services/logging/logger';
 import {
   MESSAGE_CONTEXT_EXTRACTOR_ID,
@@ -56,7 +60,8 @@ export class TelegramBot {
     @inject(MESSAGE_CONTEXT_EXTRACTOR_ID)
     private extractor: MessageContextExtractor,
     @inject(TRIGGER_PIPELINE_ID) private pipeline: TriggerPipeline,
-    @inject(CHAT_RESPONDER_ID) private responder: ChatResponder
+    @inject(CHAT_RESPONDER_ID) private responder: ChatResponder,
+    @inject(INTEREST_CHECKER_ID) private interestChecker: InterestChecker
   ) {
     this.env = envService.env;
     this.bot = new Telegraf(this.env.BOT_TOKEN);
@@ -175,6 +180,11 @@ export class TelegramBot {
     const meta = this.extractor.extract(ctx);
     const userMsg = MessageFactory.fromUser(ctx, meta);
     await this.messages.addMessage(userMsg);
+
+    const interest = await this.interestChecker.check(chatId);
+    if (interest) {
+      logger.info({ chatId, interest }, 'Interest check result');
+    }
 
     const context: TriggerContext = {
       text: `${userMsg.content};`,

--- a/src/container.ts
+++ b/src/container.ts
@@ -52,6 +52,10 @@ import {
   TestEnvService,
 } from './services/env/EnvService';
 import {
+  DefaultInterestChecker,
+  INTEREST_CHECKER_ID,
+} from './services/interest/InterestChecker';
+import {
   DefaultMessageContextExtractor,
   MESSAGE_CONTEXT_EXTRACTOR_ID,
   MessageContextExtractor,
@@ -98,6 +102,11 @@ container
 container
   .bind(CHAT_RESET_SERVICE_ID)
   .to(DefaultChatResetService)
+  .inSingletonScope();
+
+container
+  .bind(INTEREST_CHECKER_ID)
+  .to(DefaultInterestChecker)
   .inSingletonScope();
 
 container.bind(ADMIN_SERVICE_ID).to(AdminServiceImpl).inSingletonScope();


### PR DESCRIPTION
## Summary
- inject InterestChecker via constructor in TelegramBot
- log interest check result after saving user messages
- bind DefaultInterestChecker in container

## Testing
- `npm run build`
- `npm test`
- `npm run test:watch`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c63531d5883278c3310e26bb4d6e6