### PR TITLE
Add InterestTrigger unit tests and refine pipeline behavior

### DIFF
--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { DialogueManager } from '../src/services/chat/DialogueManager';
+import { InterestChecker } from '../src/services/interest/InterestChecker';
+import { InterestTrigger } from '../src/triggers/InterestTrigger';
+import { TriggerContext } from '../src/triggers/Trigger';
+
+class MockInterestChecker implements InterestChecker {
+  private count = 0;
+  constructor(
+    private readonly n: number,
+    private readonly interested: boolean
+  ) {}
+
+  async check(): Promise<{
+    interested: boolean;
+    messageId: string | null;
+  } | null> {
+    this.count += 1;
+    if (this.count < this.n) {
+      return null;
+    }
+    return { interested: this.interested, messageId: null };
+  }
+}
+
+describe('InterestTrigger', () => {
+  const dialogue = new DialogueManager(1000);
+  const baseCtx: TriggerContext = { text: '', replyText: '', chatId: 1 };
+
+  it('returns false when message count is below threshold', async () => {
+    const trigger = new InterestTrigger(new MockInterestChecker(3, true));
+    const res = await trigger.apply({} as any, baseCtx, dialogue);
+    expect(res).toBe(false);
+  });
+
+  it('returns true when threshold met and interested', async () => {
+    const trigger = new InterestTrigger(new MockInterestChecker(2, true));
+    await trigger.apply({} as any, baseCtx, dialogue);
+    const res = await trigger.apply({} as any, baseCtx, dialogue);
+    expect(res).toBe(true);
+  });
+
+  it('returns false when checker reports not interested', async () => {
+    const trigger = new InterestTrigger(new MockInterestChecker(2, false));
+    await trigger.apply({} as any, baseCtx, dialogue);
+    const res = await trigger.apply({} as any, baseCtx, dialogue);
+    expect(res).toBe(false);
+  });
+});

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -9,17 +9,14 @@ import { InterestChecker } from '../src/services/interest/InterestChecker';
 import { TriggerContext } from '../src/triggers/Trigger';
 
 describe('TriggerPipeline', () => {
-  const interestChecker: InterestChecker = {
-    async check() {
-      return null;
-    },
-  };
-  const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
-    new TestEnvService(),
-    interestChecker
-  );
+  const env = new TestEnvService();
 
   it('returns true when mention trigger matches', async () => {
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(env, {
+      async check() {
+        return null;
+      },
+    });
     const ctx: any = { message: { text: 'hi @bot' }, me: 'bot' };
     const context: TriggerContext = {
       text: 'hi @bot',
@@ -30,14 +27,33 @@ describe('TriggerPipeline', () => {
     expect(res).toBe(true);
   });
 
-  it('returns false when no trigger matches', async () => {
+  it('responds only when interest trigger returns true without mentions or replies', async () => {
+    let result: { interested: boolean; messageId: string | null } | null = null;
+    const interestChecker: InterestChecker = {
+      async check() {
+        return result;
+      },
+    };
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
+      env,
+      interestChecker
+    );
     const ctx: any = { message: { text: 'hello there' }, me: 'bot' };
     const context: TriggerContext = {
       text: 'hello there',
       replyText: '',
       chatId: 1,
     };
-    const res = await pipeline.shouldRespond(ctx, context);
+
+    let res = await pipeline.shouldRespond(ctx, context);
     expect(res).toBe(false);
+
+    result = { interested: false, messageId: null };
+    res = await pipeline.shouldRespond(ctx, context);
+    expect(res).toBe(false);
+
+    result = { interested: true, messageId: '1' };
+    res = await pipeline.shouldRespond(ctx, context);
+    expect(res).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for InterestTrigger logic
- ensure trigger pipeline only responds when InterestTrigger reports interest

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c6fb8f0a083279bab62a25f3d7293