### PR TITLE
feat: use chat memory manager

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -22,10 +22,6 @@ import {
   MessageContextExtractor,
 } from '../services/messages/MessageContextExtractor';
 import { MessageFactory } from '../services/messages/MessageFactory';
-import {
-  MESSAGE_SERVICE_ID,
-  MessageService,
-} from '../services/messages/MessageService';
 import { TriggerContext } from '../triggers/Trigger';
 
 async function withTyping(ctx: Context, fn: () => Promise<void>) {
@@ -52,7 +48,6 @@ export class TelegramBot {
     @inject(ChatMemoryManager) private memories: ChatMemoryManager,
     @inject(CHAT_FILTER_ID) private filter: ChatFilter,
     @inject(ADMIN_SERVICE_ID) private admin: AdminService,
-    @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(MESSAGE_CONTEXT_EXTRACTOR_ID)
     private extractor: MessageContextExtractor,
     @inject(TRIGGER_PIPELINE_ID) private pipeline: TriggerPipeline,
@@ -174,7 +169,7 @@ export class TelegramBot {
 
     const meta = this.extractor.extract(ctx);
     const userMsg = MessageFactory.fromUser(ctx, meta);
-    await this.messages.addMessage(userMsg);
+    await this.memories.get(chatId).addMessage(userMsg);
 
     const context: TriggerContext = {
       text: `${userMsg.content};`,

--- a/src/services/chat/ChatResponder.ts
+++ b/src/services/chat/ChatResponder.ts
@@ -4,11 +4,11 @@ import { Context } from 'telegraf';
 
 import { AI_SERVICE_ID, AIService } from '../ai/AIService';
 import { MessageFactory } from '../messages/MessageFactory';
-import { MESSAGE_SERVICE_ID, MessageService } from '../messages/MessageService';
 import {
   SUMMARY_SERVICE_ID,
   SummaryService,
 } from '../summaries/SummaryService';
+import { ChatMemoryManager } from './ChatMemory';
 
 export interface ChatResponder {
   generate(ctx: Context, chatId: number): Promise<string>;
@@ -22,15 +22,16 @@ export const CHAT_RESPONDER_ID = Symbol.for(
 export class DefaultChatResponder implements ChatResponder {
   constructor(
     @inject(AI_SERVICE_ID) private ai: AIService,
-    @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
+    @inject(ChatMemoryManager) private memories: ChatMemoryManager,
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
   ) {}
 
   async generate(ctx: Context, chatId: number): Promise<string> {
-    const history = await this.messages.getMessages(chatId);
+    const memory = this.memories.get(chatId);
+    const history = await memory.getHistory();
     const summary = await this.summaries.getSummary(chatId);
     const answer = await this.ai.ask(history, summary);
-    await this.messages.addMessage(MessageFactory.fromAssistant(ctx, answer));
+    await memory.addMessage(MessageFactory.fromAssistant(ctx, answer));
     return answer;
   }
 }

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { ChatMessage } from '../src/services/ai/AIService';
+import { ChatMemoryManager } from '../src/services/chat/ChatMemory';
 import {
   ChatResponder,
   DefaultChatResponder,
 } from '../src/services/chat/ChatResponder';
-import { MessageService } from '../src/services/messages/MessageService';
 import { SummaryService } from '../src/services/summaries/SummaryService';
 
 class MockAIService {
@@ -24,23 +24,22 @@ class MockAIService {
   }
 }
 
-class MockMessageService implements MessageService {
+class MockChatMemory {
   messages: ChatMessage[] = [];
   async addMessage(msg: any): Promise<void> {
     this.messages.push(msg);
   }
-  async getMessages(_chatId: number): Promise<ChatMessage[]> {
+  async getHistory(): Promise<ChatMessage[]> {
     return [...this.messages];
   }
-  async getCount(): Promise<number> {
-    return this.messages.length;
+}
+
+class MockChatMemoryManager implements ChatMemoryManager {
+  memory = new MockChatMemory();
+  get(_chatId: number): any {
+    return this.memory;
   }
-  async getLastMessages(_: number, limit: number): Promise<ChatMessage[]> {
-    return [...this.messages].slice(-limit).reverse();
-  }
-  async clearMessages(): Promise<void> {
-    this.messages = [];
-  }
+  async reset(): Promise<void> {}
 }
 
 class MockSummaryService implements SummaryService {
@@ -53,22 +52,22 @@ class MockSummaryService implements SummaryService {
 describe('ChatResponder', () => {
   it('generates answer and stores assistant message', async () => {
     const ai = new MockAIService();
-    const messages = new MockMessageService();
+    const memories = new MockChatMemoryManager();
     const summaries = new MockSummaryService();
     const responder: ChatResponder = new DefaultChatResponder(
       ai as any,
-      messages,
+      memories as any,
       summaries
     );
 
-    await messages.addMessage({ role: 'user', content: 'hi' });
+    await memories.get(1).addMessage({ role: 'user', content: 'hi' });
     const ctx: any = { me: 'bot', chat: { id: 1 } };
 
     const answer = await responder.generate(ctx, 1);
     expect(answer).toBe('answer');
     expect(ai.history).toHaveLength(1);
-    expect(messages.messages).toHaveLength(2);
-    expect(messages.messages[1].role).toBe('assistant');
-    expect(messages.messages[1].content).toBe('answer');
+    expect(memories.memory.messages).toHaveLength(2);
+    expect(memories.memory.messages[1].role).toBe('assistant');
+    expect(memories.memory.messages[1].content).toBe('answer');
   });
 });

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TelegramBot } from '../src/bot/TelegramBot';
+
+class MockEnvService {
+  env = { BOT_TOKEN: 'token' } as any;
+}
+
+class MockChatMemory {
+  addMessage = vi.fn();
+  getHistory = vi.fn(async () => []);
+}
+
+class MockChatMemoryManager {
+  memory = new MockChatMemory();
+  get = vi.fn(() => this.memory);
+  reset = vi.fn();
+}
+
+class AllowAllFilter {
+  isAllowed = vi.fn(() => true);
+}
+
+class DummyAdmin {}
+
+class DummyExtractor {
+  extract() {
+    return {};
+  }
+}
+
+class DummyPipeline {
+  shouldRespond = vi.fn(async () => false);
+}
+
+class DummyResponder {
+  generate = vi.fn(async () => '');
+}
+
+describe('TelegramBot', () => {
+  it('stores user messages via ChatMemoryManager', async () => {
+    const memories = new MockChatMemoryManager();
+    const configureSpy = vi
+      .spyOn(TelegramBot.prototype as any, 'configure')
+      .mockImplementation(() => {});
+    const bot = new TelegramBot(
+      new MockEnvService() as any,
+      memories as any,
+      new AllowAllFilter() as any,
+      new DummyAdmin() as any,
+      new DummyExtractor() as any,
+      new DummyPipeline() as any,
+      new DummyResponder() as any
+    );
+    configureSpy.mockRestore();
+
+    const ctx: any = {
+      chat: { id: 1 },
+      from: { id: 2 },
+      message: { text: 'hi', message_id: 3 },
+    };
+
+    await (bot as any).handleText(ctx);
+
+    expect(memories.get).toHaveBeenCalledWith(1);
+    expect(memories.memory.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'user', content: 'hi' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- route TelegramBot and ChatResponder through ChatMemoryManager to handle message history
- add tests exercising ChatMemoryManager use

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c7cefe46883278afae7ea8f28b8b6