### PR TITLE
feat: include trigger metadata for responses

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -178,21 +178,24 @@ export class TelegramBot {
     };
 
     logger.debug({ chatId }, 'Checking triggers');
-    const shouldRespond = await this.pipeline.shouldRespond(ctx, context);
-    if (!shouldRespond) {
+    const triggerResult = await this.pipeline.shouldRespond(ctx, context);
+    if (!triggerResult) {
       logger.debug({ chatId }, 'No trigger matched');
       return;
     }
 
     await withTyping(ctx, async () => {
       logger.debug({ chatId }, 'Generating answer');
-      const answer = await this.responder.generate(ctx, chatId);
+      const answer = await this.responder.generate(
+        ctx,
+        chatId,
+        triggerResult.reason ?? undefined
+      );
       logger.debug({ chatId }, 'Answer generated');
 
+      const replyId = triggerResult.replyToMessageId ?? userMsg.messageId;
       ctx.reply(answer, {
-        reply_parameters: userMsg.messageId
-          ? { message_id: userMsg.messageId }
-          : undefined,
+        reply_parameters: replyId ? { message_id: replyId } : undefined,
       });
       logger.debug({ chatId }, 'Reply sent');
     });

--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -12,7 +12,11 @@ export interface ChatMessage {
 }
 
 export interface AIService {
-  ask(history: ChatMessage[], summary?: string): Promise<string>;
+  ask(
+    history: ChatMessage[],
+    summary?: string,
+    triggerReason?: string
+  ): Promise<string>;
   summarize(history: ChatMessage[], prev?: string): Promise<string>;
   checkInterest(
     history: ChatMessage[],

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -50,7 +50,11 @@ export class ChatGPTService implements AIService {
     }
   }
 
-  public async ask(history: ChatMessage[], summary?: string): Promise<string> {
+  public async ask(
+    history: ChatMessage[],
+    summary?: string,
+    triggerReason?: string
+  ): Promise<string> {
     const persona = await this.prompts.getPersona();
     logger.debug(
       { messages: history.length, summary: !!summary },
@@ -71,6 +75,12 @@ export class ChatGPTService implements AIService {
       messages.push({
         role: 'system',
         content: await this.prompts.getAskSummaryPrompt(summary),
+      });
+    }
+    if (triggerReason) {
+      messages.push({
+        role: 'system',
+        content: `Trigger reason: ${triggerReason}`,
       });
     }
 

--- a/src/services/chat/ChatResponder.ts
+++ b/src/services/chat/ChatResponder.ts
@@ -11,7 +11,11 @@ import {
 import { ChatMemoryManager } from './ChatMemory';
 
 export interface ChatResponder {
-  generate(ctx: Context, chatId: number): Promise<string>;
+  generate(
+    ctx: Context,
+    chatId: number,
+    triggerReason?: string
+  ): Promise<string>;
 }
 
 export const CHAT_RESPONDER_ID = Symbol.for(
@@ -26,11 +30,15 @@ export class DefaultChatResponder implements ChatResponder {
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
   ) {}
 
-  async generate(ctx: Context, chatId: number): Promise<string> {
+  async generate(
+    ctx: Context,
+    chatId: number,
+    triggerReason?: string
+  ): Promise<string> {
     const memory = this.memories.get(chatId);
     const history = await memory.getHistory();
     const summary = await this.summaries.getSummary(chatId);
-    const answer = await this.ai.ask(history, summary);
+    const answer = await this.ai.ask(history, summary, triggerReason);
     await memory.addMessage(MessageFactory.fromAssistant(ctx, answer));
     return answer;
   }

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -3,7 +3,7 @@ import { Context } from 'telegraf';
 import { DialogueManager } from '../services/chat/DialogueManager';
 import { InterestChecker } from '../services/interest/InterestChecker';
 import { logger } from '../services/logging/logger';
-import { Trigger, TriggerContext } from './Trigger';
+import { Trigger, TriggerContext, TriggerResult } from './Trigger';
 
 export class InterestTrigger implements Trigger {
   constructor(private checker: InterestChecker) {}
@@ -12,12 +12,15 @@ export class InterestTrigger implements Trigger {
     _ctx: Context,
     { chatId }: TriggerContext,
     _dialogue: DialogueManager
-  ): Promise<boolean> {
+  ): Promise<TriggerResult | null> {
     const result = await this.checker.check(chatId);
     if (result) {
       logger.debug({ chatId }, 'Interest trigger matched');
-      return true;
+      return {
+        replyToMessageId: result.messageId ? Number(result.messageId) : null,
+        reason: result.why,
+      };
     }
-    return false;
+    return null;
   }
 }

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -2,20 +2,20 @@ import { Context } from 'telegraf';
 
 import { DialogueManager } from '../services/chat/DialogueManager';
 import { logger } from '../services/logging/logger';
-import { Trigger, TriggerContext } from './Trigger';
+import { Trigger, TriggerContext, TriggerResult } from './Trigger';
 
 export class MentionTrigger implements Trigger {
   async apply(
     ctx: Context,
     context: TriggerContext,
     _dialogue: DialogueManager
-  ): Promise<boolean> {
+  ): Promise<TriggerResult | null> {
     const text = (ctx.message as any)?.text ?? '';
     if (text.includes(`@${ctx.me}`)) {
       context.text = text.replace(`@${(ctx as any).me}`, '').trim();
       logger.debug({ chatId: context.chatId }, 'Mention trigger matched');
-      return true;
+      return { replyToMessageId: null, reason: null };
     }
-    return false;
+    return null;
   }
 }

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -2,7 +2,7 @@ import { Context } from 'telegraf';
 
 import { DialogueManager } from '../services/chat/DialogueManager';
 import { logger } from '../services/logging/logger';
-import { Trigger, TriggerContext } from './Trigger';
+import { Trigger, TriggerContext, TriggerResult } from './Trigger';
 
 export class NameTrigger implements Trigger {
   private pattern: RegExp;
@@ -13,13 +13,13 @@ export class NameTrigger implements Trigger {
     ctx: Context,
     context: TriggerContext,
     _dialogue: DialogueManager
-  ): Promise<boolean> {
+  ): Promise<TriggerResult | null> {
     const text = context.text;
     if (this.pattern.test(text)) {
       context.text = text.replace(this.pattern, '').trim();
       logger.debug({ chatId: context.chatId }, 'Name trigger matched');
-      return true;
+      return { replyToMessageId: null, reason: null };
     }
-    return false;
+    return null;
   }
 }

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -2,20 +2,20 @@ import { Context } from 'telegraf';
 
 import { DialogueManager } from '../services/chat/DialogueManager';
 import { logger } from '../services/logging/logger';
-import { Trigger, TriggerContext } from './Trigger';
+import { Trigger, TriggerContext, TriggerResult } from './Trigger';
 
 export class ReplyTrigger implements Trigger {
   async apply(
     ctx: Context,
     context: TriggerContext,
     _dialogue: DialogueManager
-  ): Promise<boolean> {
+  ): Promise<TriggerResult | null> {
     const reply = (ctx.message as any)?.reply_to_message;
 
     if (reply?.from?.username === ctx.me) {
       logger.debug({ chatId: context.chatId }, 'Reply trigger matched');
-      return true;
+      return { replyToMessageId: null, reason: null };
     }
-    return false;
+    return null;
   }
 }

--- a/src/triggers/Trigger.ts
+++ b/src/triggers/Trigger.ts
@@ -8,10 +8,15 @@ export interface TriggerContext {
   chatId: number;
 }
 
+export interface TriggerResult {
+  replyToMessageId: number | null;
+  reason: string | null;
+}
+
 export interface Trigger {
   apply(
     ctx: Context,
     context: TriggerContext,
     dialogue: DialogueManager
-  ): Promise<boolean>;
+  ): Promise<TriggerResult | null>;
 }

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -11,9 +11,11 @@ import { SummaryService } from '../src/services/summaries/SummaryService';
 class MockAIService {
   history: ChatMessage[] | undefined;
   summary: string | undefined;
-  async ask(h: ChatMessage[], s?: string): Promise<string> {
+  reason: string | undefined;
+  async ask(h: ChatMessage[], s?: string, r?: string): Promise<string> {
     this.history = h;
     this.summary = s;
+    this.reason = r;
     return 'answer';
   }
   async summarize(): Promise<string> {
@@ -63,9 +65,10 @@ describe('ChatResponder', () => {
     await memories.get(1).addMessage({ role: 'user', content: 'hi' });
     const ctx: any = { me: 'bot', chat: { id: 1 } };
 
-    const answer = await responder.generate(ctx, 1);
+    const answer = await responder.generate(ctx, 1, 'why');
     expect(answer).toBe('answer');
     expect(ai.history).toHaveLength(1);
+    expect(ai.reason).toBe('why');
     expect(memories.memory.messages).toHaveLength(2);
     expect(memories.memory.messages[1].role).toBe('assistant');
     expect(memories.memory.messages[1].content).toBe('answer');

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -9,18 +9,15 @@ class MockInterestChecker implements InterestChecker {
   private count = 0;
   constructor(
     private readonly n: number,
-    private readonly interested: boolean
+    private readonly result: { messageId: string; why: string } | null
   ) {}
 
-  async check(): Promise<{
-    interested: boolean;
-    messageId: string | null;
-  } | null> {
+  async check(): Promise<{ messageId: string; why: string } | null> {
     this.count += 1;
     if (this.count < this.n) {
       return null;
     }
-    return { interested: this.interested, messageId: null };
+    return this.result;
   }
 }
 
@@ -28,23 +25,29 @@ describe('InterestTrigger', () => {
   const dialogue = new DialogueManager(1000);
   const baseCtx: TriggerContext = { text: '', replyText: '', chatId: 1 };
 
-  it('returns false when message count is below threshold', async () => {
-    const trigger = new InterestTrigger(new MockInterestChecker(3, true));
+  it('returns null when message count is below threshold', async () => {
+    const trigger = new InterestTrigger(
+      new MockInterestChecker(3, { messageId: '1', why: 'because' })
+    );
     const res = await trigger.apply({} as any, baseCtx, dialogue);
-    expect(res).toBe(false);
+    expect(res).toBeNull();
   });
 
-  it('returns true when threshold met and interested', async () => {
-    const trigger = new InterestTrigger(new MockInterestChecker(2, true));
+  it('returns result when threshold met and interested', async () => {
+    const trigger = new InterestTrigger(
+      new MockInterestChecker(2, { messageId: '1', why: 'because' })
+    );
     await trigger.apply({} as any, baseCtx, dialogue);
     const res = await trigger.apply({} as any, baseCtx, dialogue);
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
+    expect(res?.replyToMessageId).toBe(1);
+    expect(res?.reason).toBe('because');
   });
 
-  it('returns false when checker reports not interested', async () => {
-    const trigger = new InterestTrigger(new MockInterestChecker(2, false));
+  it('returns null when checker reports not interested', async () => {
+    const trigger = new InterestTrigger(new MockInterestChecker(2, null));
     await trigger.apply({} as any, baseCtx, dialogue);
     const res = await trigger.apply({} as any, baseCtx, dialogue);
-    expect(res).toBe(false);
+    expect(res).toBeNull();
   });
 });

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -30,11 +30,11 @@ class DummyExtractor {
 }
 
 class DummyPipeline {
-  shouldRespond = vi.fn(async () => false);
+  shouldRespond = vi.fn(async () => null);
 }
 
 class DummyResponder {
-  generate = vi.fn(async () => '');
+  generate = vi.fn(async (_ctx?: any, _id?: number, _reason?: string) => '');
 }
 
 describe('TelegramBot', () => {

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -11,7 +11,7 @@ import { TriggerContext } from '../src/triggers/Trigger';
 describe('TriggerPipeline', () => {
   const env = new TestEnvService();
 
-  it('returns true when mention trigger matches', async () => {
+  it('returns result when mention trigger matches', async () => {
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(env, {
       async check() {
         return null;
@@ -24,11 +24,11 @@ describe('TriggerPipeline', () => {
       chatId: 1,
     };
     const res = await pipeline.shouldRespond(ctx, context);
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
   });
 
-  it('responds only when interest trigger returns true without mentions or replies', async () => {
-    let result: { interested: boolean; messageId: string | null } | null = null;
+  it('responds only when interest trigger returns result without mentions or replies', async () => {
+    let result: { messageId: string; why: string } | null = null;
     const interestChecker: InterestChecker = {
       async check() {
         return result;
@@ -46,14 +46,10 @@ describe('TriggerPipeline', () => {
     };
 
     let res = await pipeline.shouldRespond(ctx, context);
-    expect(res).toBe(false);
+    expect(res).toBeNull();
 
-    result = { interested: false, messageId: null };
+    result = { messageId: '1', why: 'because' };
     res = await pipeline.shouldRespond(ctx, context);
-    expect(res).toBe(false);
-
-    result = { interested: true, messageId: '1' };
-    res = await pipeline.shouldRespond(ctx, context);
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
   });
 });

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -9,25 +9,27 @@ import { TriggerContext } from '../src/triggers/Trigger';
 describe('MentionTrigger', () => {
   const trigger = new MentionTrigger();
 
-  it('removes bot mention and returns true', async () => {
+  it('removes bot mention and returns result', async () => {
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx: any = {
       message: { text: 'hello @bot' },
       me: 'bot',
     };
     const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
+    expect(res?.replyToMessageId).toBeNull();
+    expect(res?.reason).toBeNull();
     expect(ctx.text).toBe('hello');
   });
 
-  it('returns false without mention', async () => {
+  it('returns null without mention', async () => {
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx: any = {
       message: { text: 'hello there' },
       me: 'bot',
     };
     const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
-    expect(res).toBe(false);
+    expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
 });
@@ -42,18 +44,18 @@ describe('NameTrigger', () => {
       chatId: 1,
     };
     const res = await trigger.apply({} as any, ctx, new DialogueManager());
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
     expect(ctx.text).toBe('how are you?');
   });
 
-  it('returns false when name missing', async () => {
+  it('returns null when name missing', async () => {
     const ctx: TriggerContext = {
       text: 'Hello Arkadius',
       replyText: '',
       chatId: 1,
     };
     const res = await trigger.apply({} as any, ctx, new DialogueManager());
-    expect(res).toBe(false);
+    expect(res).toBeNull();
     expect(ctx.text).toBe('Hello Arkadius');
   });
 });
@@ -68,13 +70,13 @@ describe('ReplyTrigger', () => {
       message: { reply_to_message: { from: { username: 'bot' } } },
     };
     const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
-    expect(res).toBe(true);
+    expect(res).not.toBeNull();
   });
 
-  it('returns false when not replying to bot', async () => {
+  it('returns null when not replying to bot', async () => {
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx: any = { me: 'bot', message: {} };
     const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
-    expect(res).toBe(false);
+    expect(res).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- allow triggers to return reply target and reason for the response
- propagate trigger metadata through pipeline and into AI prompts
- support replying to specific messages based on trigger output

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c82f8d1f483279c8fc2058cb2d183