### PR TITLE
Add chat access table migration

### DIFF
--- a/migrations/009_create_chat_access_table.down.sql
+++ b/migrations/009_create_chat_access_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS chat_access;

--- a/migrations/009_create_chat_access_table.up.sql
+++ b/migrations/009_create_chat_access_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS chat_access (
+  chat_id INTEGER PRIMARY KEY,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'banned')),
+  requested_at INTEGER,
+  approved_at INTEGER
+);


### PR DESCRIPTION
## Summary
- add migration for `chat_access` table with status tracking

## Testing
- `npm run migration:up`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8bb36a38832781654f3a35932c68