### PR TITLE
feat: add chat access repository

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -8,11 +8,13 @@ import {
   SQLiteDbProviderImpl,
 } from './repositories/DbProvider';
 import { ACCESS_KEY_REPOSITORY_ID } from './repositories/interfaces/AccessKeyRepository';
+import { CHAT_ACCESS_REPOSITORY_ID } from './repositories/interfaces/ChatAccessRepository';
 import { CHAT_REPOSITORY_ID } from './repositories/interfaces/ChatRepository';
 import { MESSAGE_REPOSITORY_ID } from './repositories/interfaces/MessageRepository';
 import { SUMMARY_REPOSITORY_ID } from './repositories/interfaces/SummaryRepository';
 import { USER_REPOSITORY_ID } from './repositories/interfaces/UserRepository';
 import { SQLiteAccessKeyRepository } from './repositories/sqlite/SQLiteAccessKeyRepository';
+import { SQLiteChatAccessRepository } from './repositories/sqlite/SQLiteChatAccessRepository';
 import { SQLiteChatRepository } from './repositories/sqlite/SQLiteChatRepository';
 import { SQLiteMessageRepository } from './repositories/sqlite/SQLiteMessageRepository';
 import { SQLiteSummaryRepository } from './repositories/sqlite/SQLiteSummaryRepository';
@@ -125,6 +127,10 @@ container
 container
   .bind(ACCESS_KEY_REPOSITORY_ID)
   .to(SQLiteAccessKeyRepository)
+  .inSingletonScope();
+container
+  .bind(CHAT_ACCESS_REPOSITORY_ID)
+  .to(SQLiteChatAccessRepository)
   .inSingletonScope();
 
 container.bind(ChatMemoryManager).toSelf().inSingletonScope();

--- a/src/repositories/interfaces/ChatAccessRepository.ts
+++ b/src/repositories/interfaces/ChatAccessRepository.ts
@@ -1,0 +1,20 @@
+import type { ServiceIdentifier } from 'inversify';
+
+export type ChatStatus = 'pending' | 'approved' | 'banned';
+
+export interface ChatAccessEntity {
+  chatId: number;
+  status: ChatStatus;
+  requestedAt?: number;
+  approvedAt?: number;
+}
+
+export interface ChatAccessRepository {
+  get(chatId: number): Promise<ChatAccessEntity | undefined>;
+  setStatus(chatId: number, status: ChatStatus): Promise<void>;
+  listPending(): Promise<ChatAccessEntity[]>;
+}
+
+export const CHAT_ACCESS_REPOSITORY_ID = Symbol.for(
+  'ChatAccessRepository'
+) as ServiceIdentifier<ChatAccessRepository>;

--- a/src/repositories/sqlite/SQLiteChatAccessRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatAccessRepository.ts
@@ -1,0 +1,73 @@
+import { inject, injectable } from 'inversify';
+
+import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
+import {
+  type ChatAccessEntity,
+  type ChatAccessRepository,
+  type ChatStatus,
+} from '../interfaces/ChatAccessRepository';
+
+@injectable()
+export class SQLiteChatAccessRepository implements ChatAccessRepository {
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+
+  private async db() {
+    return this.dbProvider.get();
+  }
+
+  async get(chatId: number): Promise<ChatAccessEntity | undefined> {
+    const db = await this.db();
+    const row = await db.get<{
+      chat_id: number;
+      status: ChatStatus;
+      requested_at: number | null;
+      approved_at: number | null;
+    }>(
+      'SELECT chat_id, status, requested_at, approved_at FROM chat_access WHERE chat_id = ?',
+      chatId
+    );
+    return row
+      ? {
+          chatId: row.chat_id,
+          status: row.status,
+          requestedAt: row.requested_at ?? undefined,
+          approvedAt: row.approved_at ?? undefined,
+        }
+      : undefined;
+  }
+
+  async setStatus(chatId: number, status: ChatStatus): Promise<void> {
+    const db = await this.db();
+    const now = Date.now();
+    const requestedAt = status === 'pending' ? now : null;
+    const approvedAt = status === 'approved' ? now : null;
+    await db.run(
+      'INSERT INTO chat_access (chat_id, status, requested_at, approved_at) VALUES (?, ?, ?, ?) ON CONFLICT(chat_id) DO UPDATE SET status=excluded.status, requested_at=excluded.requested_at, approved_at=excluded.approved_at',
+      chatId,
+      status,
+      requestedAt,
+      approvedAt
+    );
+  }
+
+  async listPending(): Promise<ChatAccessEntity[]> {
+    const db = await this.db();
+    const rows = await db.all<
+      {
+        chat_id: number;
+        status: ChatStatus;
+        requested_at: number | null;
+        approved_at: number | null;
+      }[]
+    >(
+      'SELECT chat_id, status, requested_at, approved_at FROM chat_access WHERE status = ?',
+      'pending'
+    );
+    return (rows ?? []).map((row) => ({
+      chatId: row.chat_id,
+      status: row.status,
+      requestedAt: row.requested_at ?? undefined,
+      approvedAt: row.approved_at ?? undefined,
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
- add ChatAccessRepository interface for chat status management
- implement SQLiteChatAccessRepository to store chat access status
- wire ChatAccessRepository into dependency container

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c8d32d0c88327b1735c1f93646764