### PR TITLE
feat: add chat approval service

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -24,6 +24,10 @@ import { AdminServiceImpl } from './services/admin/AdminServiceImpl';
 import { AI_SERVICE_ID } from './services/ai/AIService';
 import { ChatGPTService } from './services/ai/ChatGPTService';
 import {
+  CHAT_APPROVAL_SERVICE_ID,
+  DefaultChatApprovalService,
+} from './services/chat/ChatApprovalService';
+import {
   CHAT_FILTER_ID,
   JSONWhiteListChatFilter,
 } from './services/chat/ChatFilter';
@@ -104,6 +108,10 @@ container
 container
   .bind(CHAT_RESET_SERVICE_ID)
   .to(DefaultChatResetService)
+  .inSingletonScope();
+container
+  .bind(CHAT_APPROVAL_SERVICE_ID)
+  .to(DefaultChatApprovalService)
   .inSingletonScope();
 
 container

--- a/src/services/chat/ChatApprovalService.ts
+++ b/src/services/chat/ChatApprovalService.ts
@@ -1,0 +1,49 @@
+import type { ServiceIdentifier } from 'inversify';
+import { inject, injectable } from 'inversify';
+
+import {
+  CHAT_ACCESS_REPOSITORY_ID,
+  type ChatAccessRepository,
+  type ChatStatus,
+} from '../../repositories/interfaces/ChatAccessRepository';
+
+export interface ChatApprovalService {
+  request(chatId: number, title?: string): Promise<void>;
+  approve(chatId: number): Promise<void>;
+  ban(chatId: number): Promise<void>;
+  unban(chatId: number): Promise<void>;
+  getStatus(chatId: number): Promise<ChatStatus>;
+}
+
+export const CHAT_APPROVAL_SERVICE_ID = Symbol.for(
+  'ChatApprovalService'
+) as ServiceIdentifier<ChatApprovalService>;
+
+@injectable()
+export class DefaultChatApprovalService implements ChatApprovalService {
+  constructor(
+    @inject(CHAT_ACCESS_REPOSITORY_ID)
+    private accessRepo: ChatAccessRepository
+  ) {}
+
+  async request(chatId: number, title?: string): Promise<void> {
+    await this.accessRepo.setStatus(chatId, 'pending');
+  }
+
+  async approve(chatId: number): Promise<void> {
+    await this.accessRepo.setStatus(chatId, 'approved');
+  }
+
+  async ban(chatId: number): Promise<void> {
+    await this.accessRepo.setStatus(chatId, 'banned');
+  }
+
+  async unban(chatId: number): Promise<void> {
+    await this.accessRepo.setStatus(chatId, 'approved');
+  }
+
+  async getStatus(chatId: number): Promise<ChatStatus> {
+    const entity = await this.accessRepo.get(chatId);
+    return entity?.status ?? 'pending';
+  }
+}


### PR DESCRIPTION
## Summary
- add chat approval service to manage chat access states
- register chat approval service in container

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c8f3b0dcc8327b0f8d7e02115d4a3