### PR TITLE
Improve lazy loading resilience and database URL handling

### DIFF
--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,6 +1,10 @@
 export function parseDatabaseUrl(databaseUrl: string | undefined): string {
-  if (!databaseUrl) {
-    throw new Error('DATABASE_URL is required');
+  if (!databaseUrl || databaseUrl.trim() === '') {
+    throw new Error('DATABASE_URL environment variable is required');
   }
-  return databaseUrl.replace(/^file:\/\//, '');
+  const trimmed = databaseUrl.trim();
+  if (trimmed.startsWith('file://')) {
+    return trimmed.replace(/^file:\/\//, '');
+  }
+  return trimmed;
 }

--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -6,10 +6,15 @@ export function createLazy<T>(loader: () => Promise<T>): () => Promise<T> {
       return cache;
     }
     if (!promise) {
-      promise = loader().then((value) => {
-        cache = value;
-        return value;
-      });
+      promise = loader()
+        .then((value) => {
+          cache = value;
+          return value;
+        })
+        .catch((error) => {
+          promise = null;
+          throw error;
+        });
     }
     return promise;
   };

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -7,7 +7,22 @@ describe('parseDatabaseUrl', () => {
     expect(parseDatabaseUrl('file:///tmp/db.sqlite')).toBe('/tmp/db.sqlite');
   });
 
-  it('throws when URL is undefined', () => {
-    expect(() => parseDatabaseUrl(undefined)).toThrow();
+  it('returns path as-is when no prefix is provided', () => {
+    expect(parseDatabaseUrl('/tmp/db.sqlite')).toBe('/tmp/db.sqlite');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseDatabaseUrl('  file:///tmp/db.sqlite  ')).toBe(
+      '/tmp/db.sqlite'
+    );
+  });
+
+  it('throws when URL is undefined or empty', () => {
+    expect(() => parseDatabaseUrl(undefined)).toThrow(
+      'DATABASE_URL environment variable is required'
+    );
+    expect(() => parseDatabaseUrl('')).toThrow(
+      'DATABASE_URL environment variable is required'
+    );
   });
 });

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createLazy } from '../src/utils/lazy';
+
+describe('createLazy', () => {
+  it('caches successful results', async () => {
+    const loader = vi.fn().mockResolvedValue(1);
+    const lazy = createLazy(loader);
+
+    await expect(lazy()).resolves.toBe(1);
+    await expect(lazy()).resolves.toBe(1);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries loading after failure', async () => {
+    const loader = vi
+      .fn<[], Promise<number>>()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(2);
+
+    const lazy = createLazy(loader);
+
+    await expect(lazy()).rejects.toThrow('fail');
+    await expect(lazy()).resolves.toBe(2);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Reset cached promise in `createLazy` after rejection so operations can retry
- Trim and accept plain paths in `parseDatabaseUrl` with clearer error messages
- Add unit tests covering lazy loader retries and database URL edge cases

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689da10415748327a06a4c434e90f697