### PR TITLE
Link chat and user in RepositoryMessageService

### DIFF
--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -5,6 +5,10 @@ import {
   type ChatRepository,
 } from '../../repositories/interfaces/ChatRepository';
 import {
+  CHAT_USER_REPOSITORY_ID,
+  type ChatUserRepository,
+} from '../../repositories/interfaces/ChatUserRepository';
+import {
   MESSAGE_REPOSITORY_ID,
   type MessageRepository,
 } from '../../repositories/interfaces/MessageRepository';
@@ -21,7 +25,8 @@ export class RepositoryMessageService implements MessageService {
   constructor(
     @inject(CHAT_REPOSITORY_ID) private chatRepo: ChatRepository,
     @inject(USER_REPOSITORY_ID) private userRepo: UserRepository,
-    @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository
+    @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository,
+    @inject(CHAT_USER_REPOSITORY_ID) private chatUserRepo: ChatUserRepository
   ) {}
 
   async addMessage(message: StoredMessage) {
@@ -40,6 +45,7 @@ export class RepositoryMessageService implements MessageService {
       firstName: message.firstName ?? null,
       lastName: message.lastName ?? null,
     });
+    await this.chatUserRepo.link(message.chatId, storedUserId);
     await this.messageRepo.insert({
       ...message,
       userId: storedUserId,

--- a/test/RepositoryMessageService.test.ts
+++ b/test/RepositoryMessageService.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { type ChatRepository } from '../src/repositories/interfaces/ChatRepository';
+import { type ChatUserRepository } from '../src/repositories/interfaces/ChatUserRepository';
+import { type MessageRepository } from '../src/repositories/interfaces/MessageRepository';
+import { type UserRepository } from '../src/repositories/interfaces/UserRepository';
+import { RepositoryMessageService } from '../src/services/messages/RepositoryMessageService';
+import { type StoredMessage } from '../src/services/messages/StoredMessage';
+
+describe('RepositoryMessageService', () => {
+  it('links chat and user when adding a message', async () => {
+    const chatRepo: ChatRepository = {
+      upsert: vi.fn(),
+    } as unknown as ChatRepository;
+    const userRepo: UserRepository = {
+      upsert: vi.fn(),
+    } as unknown as UserRepository;
+    const messageRepo: MessageRepository = {
+      insert: vi.fn(),
+    } as unknown as MessageRepository;
+    const chatUserRepo: ChatUserRepository = {
+      link: vi.fn(),
+    } as unknown as ChatUserRepository;
+
+    const service = new RepositoryMessageService(
+      chatRepo,
+      userRepo,
+      messageRepo,
+      chatUserRepo
+    );
+
+    const message: StoredMessage = {
+      chatId: 123,
+      role: 'user',
+      content: 'hello',
+      userId: 456,
+    };
+
+    await service.addMessage(message);
+
+    expect(chatUserRepo.link).toHaveBeenCalledWith(123, 456);
+  });
+});


### PR DESCRIPTION
## Summary
- inject ChatUserRepository into RepositoryMessageService
- link chat and user when storing a message
- add unit test for chat-user linking

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689da90b54f08327b132fcc9be7913ac