### PR TITLE
Assess user attitudes during summarization

### DIFF
--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -25,7 +25,8 @@ export interface AIService {
     summary: string
   ): Promise<{ messageId: string; why: string } | null>;
   assessUsers(
-    messages: ChatMessage[]
+    messages: ChatMessage[],
+    prevAttitudes?: { username: string; attitude: string }[]
   ): Promise<{ username: string; attitude: string }[]>;
 }
 

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -171,7 +171,8 @@ export class ChatGPTService implements AIService {
   }
 
   public async assessUsers(
-    messages: ChatMessage[]
+    messages: ChatMessage[],
+    prevAttitudes: { username: string; attitude: string }[] = []
   ): Promise<{ username: string; attitude: string }[]> {
     const persona = await this.prompts.getPersona();
     const systemPrompt =
@@ -180,6 +181,15 @@ export class ChatGPTService implements AIService {
       { role: 'system', content: persona },
       { role: 'system', content: systemPrompt },
     ];
+    if (prevAttitudes.length > 0) {
+      const attitudesText = prevAttitudes
+        .map((a) => `${a.username}: ${a.attitude}`)
+        .join('\n');
+      reqMessages.push({
+        role: 'system',
+        content: `Предыдущее отношение бота к пользователям:\n${attitudesText}`,
+      });
+    }
     const historyMessages = await Promise.all(
       messages.map<Promise<OpenAI.ChatCompletionMessageParam>>(async (m) =>
         m.role === 'user'

--- a/src/services/chat/HistorySummarizer.ts
+++ b/src/services/chat/HistorySummarizer.ts
@@ -68,7 +68,19 @@ export class DefaultHistorySummarizer implements HistorySummarizer {
       'Generated new summary'
     );
 
-    const assessments = await this.ai.assessUsers(history);
+    const prevAttitudes: { username: string; attitude: string }[] = [];
+    const seen = new Set<number>();
+    for (const m of history) {
+      if (m.userId !== undefined && m.username && !seen.has(m.userId)) {
+        seen.add(m.userId);
+        const user = await this.users.findById(m.userId);
+        if (user?.attitude) {
+          prevAttitudes.push({ username: m.username, attitude: user.attitude });
+        }
+      }
+    }
+
+    const assessments = await this.ai.assessUsers(history, prevAttitudes);
     logger.debug(
       { chatId, assessments: assessments.length },
       'Assessed user attitudes'


### PR DESCRIPTION
## Summary
- extend AIService with `assessUsers` to evaluate user attitudes
- implement `ChatGPTService.assessUsers` to request attitudes as JSON
- run `HistorySummarizer` after summarization to assess users and store attitudes via `UserRepository`

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dacbac4f8832781c2a621ffde39c3