### PR TITLE
Propagate chat user attitudes to AI requests

### DIFF
--- a/src/services/ai/AIService.ts
+++ b/src/services/ai/AIService.ts
@@ -17,7 +17,8 @@ export interface AIService {
   ask(
     history: ChatMessage[],
     summary?: string,
-    triggerReason?: TriggerReason
+    triggerReason?: TriggerReason,
+    attitudes?: { username: string; attitude?: string | null }[]
   ): Promise<string>;
   summarize(history: ChatMessage[], prev?: string): Promise<string>;
   checkInterest(

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -54,7 +54,8 @@ export class ChatGPTService implements AIService {
   public async ask(
     history: ChatMessage[],
     summary?: string,
-    triggerReason?: TriggerReason
+    triggerReason?: TriggerReason,
+    attitudes: { username: string; attitude?: string | null }[] = []
   ): Promise<string> {
     const persona = await this.prompts.getPersona();
     logger.debug(
@@ -89,6 +90,13 @@ export class ChatGPTService implements AIService {
         role: 'system',
         content: `Trigger message: ${triggerReason.message}`,
       });
+    }
+
+    if (attitudes.length > 0) {
+      const attitudeText = attitudes
+        .map((a) => `@${a.username} — ${a.attitude ?? ''}`)
+        .join('; ');
+      messages.push({ role: 'system', content: `Attitude: ${attitudeText}` });
     }
 
     const historyMessages = await Promise.all(

--- a/src/services/chat/ChatResponder.ts
+++ b/src/services/chat/ChatResponder.ts
@@ -2,6 +2,14 @@ import type { ServiceIdentifier } from 'inversify';
 import { inject, injectable } from 'inversify';
 import { Context } from 'telegraf';
 
+import {
+  CHAT_USER_REPOSITORY_ID,
+  ChatUserRepository,
+} from '../../repositories/interfaces/ChatUserRepository';
+import {
+  USER_REPOSITORY_ID,
+  UserRepository,
+} from '../../repositories/interfaces/UserRepository';
 import { TriggerReason } from '../../triggers/Trigger';
 import { AI_SERVICE_ID, AIService } from '../ai/AIService';
 import { MessageFactory } from '../messages/MessageFactory';
@@ -28,7 +36,10 @@ export class DefaultChatResponder implements ChatResponder {
   constructor(
     @inject(AI_SERVICE_ID) private ai: AIService,
     @inject(ChatMemoryManager) private memories: ChatMemoryManager,
-    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
+    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
+    @inject(CHAT_USER_REPOSITORY_ID)
+    private readonly chatUsers: ChatUserRepository,
+    @inject(USER_REPOSITORY_ID) private readonly users: UserRepository
   ) {}
 
   async generate(
@@ -39,7 +50,26 @@ export class DefaultChatResponder implements ChatResponder {
     const memory = this.memories.get(chatId);
     const history = await memory.getHistory();
     const summary = await this.summaries.getSummary(chatId);
-    const answer = await this.ai.ask(history, summary, triggerReason);
+    const userIds = await this.chatUsers.listByChat(chatId);
+    const attitudes = (
+      await Promise.all(
+        userIds.map(async (id) => {
+          const user = await this.users.findById(id);
+          if (!user?.username) {
+            return null;
+          }
+          return { username: user.username, attitude: user.attitude ?? null };
+        })
+      )
+    ).filter(
+      (a): a is { username: string; attitude: string | null } => a !== null
+    );
+    const answer = await this.ai.ask(
+      history,
+      summary,
+      triggerReason,
+      attitudes
+    );
     await memory.addMessage(MessageFactory.fromAssistant(ctx, answer));
     return answer;
   }


### PR DESCRIPTION
## Summary
- add attitudes parameter to AIService.ask
- gather chat users' attitudes and forward them in ChatResponder
- include attitudes system prompt in ChatGPTService

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689daf95ad788327a1da98ae1d52511d