### PR TITLE
Short-circuit trigger pipeline evaluation

### DIFF
--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -49,13 +49,14 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     const chatId = context.chatId;
     const inDialogue = this.dialogue.isActive(chatId);
     let result: TriggerResult | null = null;
-    result =
-      (await this.mentionTrigger.apply(ctx, context, this.dialogue)) ?? result;
-    result =
-      (await this.replyTrigger.apply(ctx, context, this.dialogue)) ?? result;
-    result =
-      (await this.nameTrigger.apply(ctx, context, this.dialogue)) ?? result;
 
+    result = await this.mentionTrigger.apply(ctx, context, this.dialogue);
+    if (!result) {
+      result = await this.replyTrigger.apply(ctx, context, this.dialogue);
+    }
+    if (!result) {
+      result = await this.nameTrigger.apply(ctx, context, this.dialogue);
+    }
     if (!result) {
       result = await this.interestTrigger.apply(ctx, context, this.dialogue);
     }

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   DefaultTriggerPipeline,
@@ -25,6 +25,25 @@ describe('TriggerPipeline', () => {
     };
     const res = await pipeline.shouldRespond(ctx, context);
     expect(res).not.toBeNull();
+  });
+
+  it('exits early when a trigger matches', async () => {
+    const interestChecker: InterestChecker = {
+      check: vi.fn().mockResolvedValue(null),
+    };
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
+      env,
+      interestChecker
+    );
+    const ctx: any = { message: { text: 'hi @bot' }, me: 'bot' };
+    const context: TriggerContext = {
+      text: 'hi @bot',
+      replyText: '',
+      chatId: 1,
+    };
+    const res = await pipeline.shouldRespond(ctx, context);
+    expect(res).not.toBeNull();
+    expect(interestChecker.check).not.toHaveBeenCalled();
   });
 
   it('responds only when interest trigger returns result without mentions or replies', async () => {


### PR DESCRIPTION
## Summary
- avoid calling additional triggers after a match in `TriggerPipeline`
- add unit test covering early exit of the trigger pipeline

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dbe592e7c8327949bb74fff59a241