### PR TITLE
feat: limit data export to current chat

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -139,7 +139,10 @@ export class TelegramBot {
       await ctx.answerCbQuery('Начинаю загрузку данных...');
 
       try {
-        const files = await this.admin.exportTables();
+        const files =
+          chatId === this.env.ADMIN_CHAT_ID
+            ? await this.admin.exportTables()
+            : await this.admin.exportChatData(chatId);
         if (files.length === 0) {
           await ctx.reply('Нет данных для экспорта');
           return;

--- a/src/services/admin/AdminService.ts
+++ b/src/services/admin/AdminService.ts
@@ -6,6 +6,9 @@ export interface AdminService {
   ): Promise<Date>;
   hasAccess(chatId: number, userId: number): Promise<boolean>;
   exportTables(): Promise<{ filename: string; buffer: Buffer }[]>;
+  exportChatData(
+    chatId: number
+  ): Promise<{ filename: string; buffer: Buffer }[]>;
 }
 
 import type { ServiceIdentifier } from 'inversify';

--- a/test/AdminServiceImpl.test.ts
+++ b/test/AdminServiceImpl.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AdminServiceImpl } from '../src/services/admin/AdminServiceImpl';
+
+describe('AdminServiceImpl', () => {
+  it('exports chat messages, summaries and users', async () => {
+    const messageRepo = {
+      findByChatId: vi.fn(async () => [
+        {
+          role: 'user',
+          content: 'hi',
+          username: 'u',
+          fullName: 'F',
+          replyText: '',
+          replyUsername: '',
+          quoteText: '',
+          userId: 1,
+          messageId: 1,
+          attitude: null,
+          chatId: 123,
+        },
+      ]),
+    };
+    const summaryRepo = { findById: vi.fn(async () => 's') };
+    const chatUserRepo = { listByChat: vi.fn(async () => [1]) };
+    const userRepo = {
+      findById: vi.fn(async () => ({
+        id: 1,
+        username: 'u',
+        firstName: 'F',
+        lastName: 'L',
+        attitude: null,
+      })),
+    };
+    const admin = new AdminServiceImpl(
+      { get: vi.fn(), listTables: vi.fn() } as any,
+      {} as any,
+      messageRepo as any,
+      summaryRepo as any,
+      chatUserRepo as any,
+      userRepo as any
+    );
+    const files = await admin.exportChatData(123);
+    expect(files.map((f) => f.filename).sort()).toEqual([
+      'messages.csv',
+      'summaries.csv',
+      'users.csv',
+    ]);
+    const users = files.find((f) => f.filename === 'users.csv');
+    expect(users?.buffer.toString()).toContain(
+      'id,username,firstName,lastName,attitude'
+    );
+    expect(users?.buffer.toString()).toContain('1');
+  });
+});

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -21,6 +21,7 @@ class MockChatMemoryManager {
 class DummyAdmin {
   hasAccess = vi.fn(async () => true);
   exportTables = vi.fn(async () => []);
+  exportChatData = vi.fn(async () => []);
   createAccessKey = vi.fn(async () => new Date());
 }
 


### PR DESCRIPTION
## Summary
- restrict non-admin data exports to chat-specific messages and summaries using repositories
- include chat users in non-admin chat data exports
- adjust tests for new admin service API and add AdminServiceImpl test

## Testing
- `npm test`
- `npm run build`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dbe0cd1c4832787a63e3540f83db2