### PR TITLE
Handle admin chat in menu

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -130,10 +130,12 @@ export class TelegramBot {
       assert(chatId, 'This is not a chat');
       assert(userId, 'No user id');
 
-      const allowed = await this.admin.hasAccess(chatId, userId);
-      if (!allowed) {
-        await ctx.answerCbQuery('Нет доступа или ключ просрочен');
-        return;
+      if (chatId !== this.env.ADMIN_CHAT_ID) {
+        const allowed = await this.admin.hasAccess(chatId, userId);
+        if (!allowed) {
+          await ctx.answerCbQuery('Нет доступа или ключ просрочен');
+          return;
+        }
       }
 
       await ctx.answerCbQuery('Начинаю загрузку данных...');
@@ -174,10 +176,12 @@ export class TelegramBot {
       assert(chatId, 'This is not a chat');
       assert(userId, 'No user id');
 
-      const allowed = await this.admin.hasAccess(chatId, userId);
-      if (!allowed) {
-        await ctx.answerCbQuery('Нет доступа или ключ просрочен');
-        return;
+      if (chatId !== this.env.ADMIN_CHAT_ID) {
+        const allowed = await this.admin.hasAccess(chatId, userId);
+        if (!allowed) {
+          await ctx.answerCbQuery('Нет доступа или ключ просрочен');
+          return;
+        }
       }
 
       await ctx.answerCbQuery('Сбрасываю память диалога...');
@@ -271,6 +275,11 @@ export class TelegramBot {
     const chatId = ctx.chat?.id;
     assert(chatId, 'This is not a chat');
 
+    if (chatId === this.env.ADMIN_CHAT_ID) {
+      await this.showAdminMenu(ctx);
+      return;
+    }
+
     const status = await this.approvalService.getStatus(chatId);
     if (status === 'banned') {
       await ctx.reply('Доступ к боту запрещён.');
@@ -311,9 +320,25 @@ export class TelegramBot {
     });
   }
 
+  private async showAdminMenu(ctx: Context) {
+    await ctx.reply('Выберите действие администратора:', {
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: '📊 Загрузить данные', callback_data: 'export_data' }],
+          [{ text: '🔄 Сбросить память', callback_data: 'reset_memory' }],
+        ],
+      },
+    });
+  }
+
   private async handleText(ctx: Context) {
     const chatId = ctx.chat?.id;
     assert(!!chatId, 'This is not a chat');
+    if (chatId === this.env.ADMIN_CHAT_ID) {
+      logger.debug({ chatId }, 'Ignoring admin chat message');
+      return;
+    }
+
     logger.debug({ chatId }, 'Received text message');
 
     const status = await this.approvalService.getStatus(chatId);


### PR DESCRIPTION
## Summary
- show admin-specific menu and bypass approval flow
- ignore access checks for admin data actions
- skip text handling for admin chat

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689dc1a7585c8327b326f48a0e2c1ba0