### PR TITLE
Add listAll to chat access repository and approval service

### DIFF
--- a/src/repositories/interfaces/ChatAccessRepository.ts
+++ b/src/repositories/interfaces/ChatAccessRepository.ts
@@ -13,6 +13,7 @@ export interface ChatAccessRepository {
   get(chatId: number): Promise<ChatAccessEntity | undefined>;
   setStatus(chatId: number, status: ChatStatus): Promise<void>;
   listPending(): Promise<ChatAccessEntity[]>;
+  listAll(): Promise<ChatAccessEntity[]>;
 }
 
 export const CHAT_ACCESS_REPOSITORY_ID = Symbol.for(

--- a/src/repositories/sqlite/SQLiteChatAccessRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatAccessRepository.ts
@@ -70,4 +70,22 @@ export class SQLiteChatAccessRepository implements ChatAccessRepository {
       approvedAt: row.approved_at ?? undefined,
     }));
   }
+
+  async listAll(): Promise<ChatAccessEntity[]> {
+    const db = await this.db();
+    const rows = await db.all<
+      {
+        chat_id: number;
+        status: ChatStatus;
+        requested_at: number | null;
+        approved_at: number | null;
+      }[]
+    >('SELECT chat_id, status, requested_at, approved_at FROM chat_access');
+    return (rows ?? []).map((row) => ({
+      chatId: row.chat_id,
+      status: row.status,
+      requestedAt: row.requested_at ?? undefined,
+      approvedAt: row.approved_at ?? undefined,
+    }));
+  }
 }

--- a/src/services/chat/ChatApprovalService.ts
+++ b/src/services/chat/ChatApprovalService.ts
@@ -2,6 +2,7 @@ import { inject, injectable, type ServiceIdentifier } from 'inversify';
 
 import {
   CHAT_ACCESS_REPOSITORY_ID,
+  type ChatAccessEntity,
   type ChatAccessRepository,
   type ChatStatus,
 } from '../../repositories/interfaces/ChatAccessRepository';
@@ -13,6 +14,7 @@ export interface ChatApprovalService {
   ban(chatId: number): Promise<void>;
   unban(chatId: number): Promise<void>;
   getStatus(chatId: number): Promise<ChatStatus>;
+  listAll(): Promise<ChatAccessEntity[]>;
 }
 
 export const CHAT_APPROVAL_SERVICE_ID = Symbol.for(
@@ -50,5 +52,9 @@ export class DefaultChatApprovalService implements ChatApprovalService {
   async getStatus(chatId: number): Promise<ChatStatus> {
     const entity = await this.accessRepo.get(chatId);
     return entity?.status ?? 'pending';
+  }
+
+  async listAll(): Promise<ChatAccessEntity[]> {
+    return this.accessRepo.listAll();
   }
 }

--- a/test/ChatApprovalService.test.ts
+++ b/test/ChatApprovalService.test.ts
@@ -14,6 +14,7 @@ describe('DefaultChatApprovalService', () => {
     get: vi.fn(),
     setStatus: vi.fn().mockResolvedValue(undefined),
     listPending: vi.fn(),
+    listAll: vi.fn(),
   };
 
   const envService = {
@@ -54,5 +55,12 @@ describe('DefaultChatApprovalService', () => {
 
     (repo.get as any).mockResolvedValueOnce(undefined);
     expect(await service.getStatus(6)).toBe('pending');
+  });
+
+  it('lists all chat access entries', async () => {
+    const entries = [{ chatId: 1, status: 'approved' }];
+    (repo.listAll as any).mockResolvedValueOnce(entries);
+    expect(await service.listAll()).toEqual(entries);
+    expect(repo.listAll).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add listAll method to ChatAccessRepository interface
- implement listAll for SQLiteChatAccessRepository
- expose listAll through ChatApprovalService and update tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dc483b3988327b9629650971f34d4