### PR TITLE
Add tests for RepositorySummaryService

### DIFF
--- a/test/RepositorySummaryService.test.ts
+++ b/test/RepositorySummaryService.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { type SummaryRepository } from '../src/repositories/interfaces/SummaryRepository';
+import { RepositorySummaryService } from '../src/services/summaries/RepositorySummaryService';
+
+describe('RepositorySummaryService', () => {
+  it('getSummary calls findById', async () => {
+    const summaryRepo: SummaryRepository = {
+      findById: vi.fn().mockResolvedValue(''),
+      upsert: vi.fn(),
+      clearByChatId: vi.fn(),
+    } as unknown as SummaryRepository;
+
+    const service = new RepositorySummaryService(summaryRepo);
+
+    await service.getSummary(123);
+
+    expect(summaryRepo.findById).toHaveBeenCalledWith(123);
+  });
+
+  it('setSummary calls upsert', async () => {
+    const summaryRepo: SummaryRepository = {
+      findById: vi.fn(),
+      upsert: vi.fn(),
+      clearByChatId: vi.fn(),
+    } as unknown as SummaryRepository;
+
+    const service = new RepositorySummaryService(summaryRepo);
+
+    await service.setSummary(123, 'summary');
+
+    expect(summaryRepo.upsert).toHaveBeenCalledWith(123, 'summary');
+  });
+
+  it('clearSummary calls clearByChatId', async () => {
+    const summaryRepo: SummaryRepository = {
+      findById: vi.fn(),
+      upsert: vi.fn(),
+      clearByChatId: vi.fn(),
+    } as unknown as SummaryRepository;
+
+    const service = new RepositorySummaryService(summaryRepo);
+
+    await service.clearSummary(123);
+
+    expect(summaryRepo.clearByChatId).toHaveBeenCalledWith(123);
+  });
+});


### PR DESCRIPTION
## Summary
- test RepositorySummaryService calls underlying repository methods

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689ddc7e8b288327b7ab12dd60299a61