### PR TITLE
Add ChatResetService reset test

### DIFF
--- a/test/ChatResetService.test.ts
+++ b/test/ChatResetService.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MessageService } from '../src/services/messages/MessageService';
+import type { SummaryService } from '../src/services/summaries/SummaryService';
+
+vi.mock('../src/services/logging/logger', () => ({
+  logger: { debug: vi.fn() },
+}));
+
+import { DefaultChatResetService } from '../src/services/chat/DefaultChatResetService';
+import { logger } from '../src/services/logging/logger';
+
+describe('DefaultChatResetService', () => {
+  const messages = {
+    clearMessages: vi.fn().mockResolvedValue(undefined),
+  } as unknown as MessageService;
+
+  const summaries = {
+    clearSummary: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SummaryService;
+
+  let service: DefaultChatResetService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new DefaultChatResetService(messages, summaries);
+  });
+
+  it('clears messages, summary and logs reset', async () => {
+    const chatId = 123;
+    await service.reset(chatId);
+    expect(messages.clearMessages).toHaveBeenCalledWith(chatId);
+    expect(summaries.clearSummary).toHaveBeenCalledWith(chatId);
+    expect(logger.debug).toHaveBeenCalledWith(
+      { chatId },
+      'Resetting chat data'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- test ChatResetService.reset clears messages and summary
- verify debug log output during chat reset

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689ddc7a65a083279129232897d23d4b