### PR TITLE
refactor: inject dialogue manager

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -38,6 +38,10 @@ import {
 } from './services/chat/ChatResponder';
 import { DefaultChatResetService } from './services/chat/DefaultChatResetService';
 import {
+  DefaultDialogueManager,
+  DIALOGUE_MANAGER_ID,
+} from './services/chat/DialogueManager';
+import {
   DefaultHistorySummarizer,
   HISTORY_SUMMARIZER_ID,
 } from './services/chat/HistorySummarizer';
@@ -135,6 +139,11 @@ container
   .inSingletonScope();
 
 container.bind(ChatMemoryManager).toSelf().inSingletonScope();
+
+container
+  .bind(DIALOGUE_MANAGER_ID)
+  .to(DefaultDialogueManager)
+  .inSingletonScope();
 
 container
   .bind<MessageContextExtractor>(MESSAGE_CONTEXT_EXTRACTOR_ID)

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -1,9 +1,27 @@
+import type { ServiceIdentifier } from 'inversify';
+import { inject, injectable } from 'inversify';
+
+import { ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
 import { logger } from '../logging/logger';
 
-export class DialogueManager {
-  private timers = new Map<number, NodeJS.Timeout>();
+export interface DialogueManager {
+  start(chatId: number): void;
+  extend(chatId: number): void;
+  isActive(chatId: number): boolean;
+}
 
-  constructor(private timeoutMs: number) {}
+export const DIALOGUE_MANAGER_ID = Symbol.for(
+  'DialogueManager'
+) as ServiceIdentifier<DialogueManager>;
+
+@injectable()
+export class DefaultDialogueManager implements DialogueManager {
+  private timers = new Map<number, NodeJS.Timeout>();
+  private timeoutMs: number;
+
+  constructor(@inject(ENV_SERVICE_ID) envService: EnvService) {
+    this.timeoutMs = envService.getDialogueTimeoutMs();
+  }
 
   private setTimer(chatId: number) {
     const existing = this.timers.get(chatId);

--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -15,7 +15,7 @@ import {
   INTEREST_CHECKER_ID,
   InterestChecker,
 } from '../interest/InterestChecker';
-import { DialogueManager } from './DialogueManager';
+import { DIALOGUE_MANAGER_ID, type DialogueManager } from './DialogueManager';
 
 export interface TriggerPipeline {
   shouldRespond(
@@ -30,7 +30,6 @@ export const TRIGGER_PIPELINE_ID = Symbol.for(
 
 @injectable()
 export class DefaultTriggerPipeline implements TriggerPipeline {
-  private dialogue: DialogueManager;
   private mentionTrigger = new MentionTrigger();
   private replyTrigger = new ReplyTrigger();
   private nameTrigger: NameTrigger;
@@ -38,9 +37,9 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
 
   constructor(
     @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(INTEREST_CHECKER_ID) interestChecker: InterestChecker
+    @inject(INTEREST_CHECKER_ID) interestChecker: InterestChecker,
+    @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager
   ) {
-    this.dialogue = new DialogueManager(envService.getDialogueTimeoutMs());
     this.nameTrigger = new NameTrigger(envService.getBotName());
     this.interestTrigger = new InterestTrigger(interestChecker);
   }

--- a/test/DialogueManager.test.ts
+++ b/test/DialogueManager.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { DialogueManager } from '../src/services/chat/DialogueManager';
+import {
+  DefaultDialogueManager,
+  type DialogueManager,
+} from '../src/services/chat/DialogueManager';
+import { TestEnvService } from '../src/services/env/EnvService';
 
 describe('DialogueManager', () => {
   beforeEach(() => {
@@ -8,7 +12,9 @@ describe('DialogueManager', () => {
   });
 
   it('deactivates after timeout', () => {
-    const dm = new DialogueManager(1000);
+    const env = new TestEnvService();
+    vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
+    const dm: DialogueManager = new DefaultDialogueManager(env);
     dm.start(1);
     expect(dm.isActive(1)).toBe(true);
     vi.advanceTimersByTime(1000);
@@ -16,7 +22,9 @@ describe('DialogueManager', () => {
   });
 
   it('extend resets timer', () => {
-    const dm = new DialogueManager(1000);
+    const env = new TestEnvService();
+    vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
+    const dm: DialogueManager = new DefaultDialogueManager(env);
     dm.start(1);
     vi.advanceTimersByTime(900);
     dm.extend(1);

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -1,7 +1,11 @@
 import type { Context } from 'telegraf';
 import { describe, expect, it } from 'vitest';
 
-import { DialogueManager } from '../src/services/chat/DialogueManager';
+import {
+  DefaultDialogueManager,
+  type DialogueManager,
+} from '../src/services/chat/DialogueManager';
+import { TestEnvService } from '../src/services/env/EnvService';
 import { InterestChecker } from '../src/services/interest/InterestChecker';
 import { InterestTrigger } from '../src/triggers/InterestTrigger';
 import { TriggerContext } from '../src/triggers/Trigger.interface';
@@ -31,7 +35,9 @@ class MockInterestChecker implements InterestChecker {
 }
 
 describe('InterestTrigger', () => {
-  const dialogue = new DialogueManager(1000);
+  const dialogue: DialogueManager = new DefaultDialogueManager(
+    new TestEnvService()
+  );
   const baseCtx: TriggerContext = { text: '', replyText: '', chatId: 1 };
 
   it('returns null when message count is below threshold', async () => {

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -2,6 +2,10 @@ import type { Context } from 'telegraf';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  DefaultDialogueManager,
+  type DialogueManager,
+} from '../src/services/chat/DialogueManager';
+import {
   DefaultTriggerPipeline,
   TriggerPipeline,
 } from '../src/services/chat/TriggerPipeline';
@@ -13,11 +17,16 @@ describe('TriggerPipeline', () => {
   const env = new TestEnvService();
 
   it('returns result when mention trigger matches', async () => {
-    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(env, {
-      async check() {
-        return null;
+    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
+      env,
+      {
+        async check() {
+          return null;
+        },
       },
-    });
+      dialogue
+    );
     const ctx = {
       message: { text: 'hi @bot' },
       me: 'bot',
@@ -35,9 +44,11 @@ describe('TriggerPipeline', () => {
     const interestChecker: InterestChecker = {
       check: vi.fn().mockResolvedValue(null),
     };
+    const dialogue: DialogueManager = new DefaultDialogueManager(env);
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
-      interestChecker
+      interestChecker,
+      dialogue
     );
     const ctx = {
       message: { text: 'hi @bot' },
@@ -61,9 +72,11 @@ describe('TriggerPipeline', () => {
         return result;
       },
     };
+    const dialogue: DialogueManager = new DefaultDialogueManager(env);
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
-      interestChecker
+      interestChecker,
+      dialogue
     );
     const ctx = {
       message: { text: 'hello there' },

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'telegraf';
 import { describe, expect, it } from 'vitest';
 
-import { DialogueManager } from '../src/services/chat/DialogueManager';
+import { DefaultDialogueManager } from '../src/services/chat/DialogueManager';
+import { TestEnvService } from '../src/services/env/EnvService';
 import { MentionTrigger } from '../src/triggers/MentionTrigger';
 import { NameTrigger } from '../src/triggers/NameTrigger';
 import { ReplyTrigger } from '../src/triggers/ReplyTrigger';
@@ -16,7 +17,11 @@ describe('MentionTrigger', () => {
       message: { text: 'hello @bot' },
       me: 'bot',
     } as unknown as Context;
-    const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
+    const res = await trigger.apply(
+      telegrafCtx,
+      ctx,
+      new DefaultDialogueManager(new TestEnvService())
+    );
     expect(res).not.toBeNull();
     expect(res?.replyToMessageId).toBeNull();
     expect(res?.reason).toBeNull();
@@ -29,7 +34,11 @@ describe('MentionTrigger', () => {
       message: { text: 'hello there' },
       me: 'bot',
     } as unknown as Context;
-    const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
+    const res = await trigger.apply(
+      telegrafCtx,
+      ctx,
+      new DefaultDialogueManager(new TestEnvService())
+    );
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
@@ -47,7 +56,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DialogueManager()
+      new DefaultDialogueManager(new TestEnvService())
     );
     expect(res).not.toBeNull();
     expect(ctx.text).toBe('how are you?');
@@ -62,7 +71,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DialogueManager()
+      new DefaultDialogueManager(new TestEnvService())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('Hello Arkadius');
@@ -78,14 +87,22 @@ describe('ReplyTrigger', () => {
       me: 'bot',
       message: { reply_to_message: { from: { username: 'bot' } } },
     } as unknown as Context;
-    const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
+    const res = await trigger.apply(
+      telegrafCtx,
+      ctx,
+      new DefaultDialogueManager(new TestEnvService())
+    );
     expect(res).not.toBeNull();
   });
 
   it('returns null when not replying to bot', async () => {
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = { me: 'bot', message: {} } as unknown as Context;
-    const res = await trigger.apply(telegrafCtx, ctx, new DialogueManager());
+    const res = await trigger.apply(
+      telegrafCtx,
+      ctx,
+      new DefaultDialogueManager(new TestEnvService())
+    );
     expect(res).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- refactor DialogueManager into injectable DefaultDialogueManager and export DIALOGUE_MANAGER_ID
- bind dialogue manager in container and inject into TriggerPipeline
- adjust tests to use the new DialogueManager interface

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689df272425c8327a656d0e9f63ee83c