### PR TITLE
chore(env): extend dialogue timeout

### DIFF
--- a/src/services/env/EnvService.ts
+++ b/src/services/env/EnvService.ts
@@ -98,7 +98,7 @@ export class DefaultEnvService implements EnvService {
   }
 
   getDialogueTimeoutMs(): number {
-    return 60 * 1000;
+    return 2 * 60 * 1000;
   }
 
   getMigrationsDir(): string {
@@ -152,7 +152,7 @@ export class TestEnvService implements EnvService {
   }
 
   getDialogueTimeoutMs(): number {
-    return 60 * 1000;
+    return 2 * 60 * 1000;
   }
 
   getMigrationsDir(): string {

--- a/test/EnvService.test.ts
+++ b/test/EnvService.test.ts
@@ -101,7 +101,7 @@ describe('EnvService', () => {
   it('getDialogueTimeoutMs returns timeout in ms', () => {
     setRequiredEnv();
     const env = new TestEnvService();
-    expect(env.getDialogueTimeoutMs()).toBe(60_000);
+    expect(env.getDialogueTimeoutMs()).toBe(120_000);
   });
 
   it('getMigrationsDir returns migrations directory', () => {


### PR DESCRIPTION
## Summary
- double dialogue timeout to two minutes
- adjust EnvService tests for new timeout

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689df52bfe5c832797d70e6b2b5d8d7f