### PR TITLE
Skip interest trigger during active dialogues

### DIFF
--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -59,7 +59,7 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     if (!result) {
       result = await this.nameTrigger.apply(ctx, context, this.dialogue);
     }
-    if (!result) {
+    if (!result && !inDialogue) {
       result = await this.interestTrigger.apply(ctx, context, this.dialogue);
     }
 

--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -59,7 +59,7 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     if (!result) {
       result = await this.nameTrigger.apply(ctx, context, this.dialogue);
     }
-    if (!result && !inDialogue) {
+    if (!result) {
       result = await this.interestTrigger.apply(ctx, context, this.dialogue);
     }
 

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -11,8 +11,12 @@ export class InterestTrigger implements Trigger {
   async apply(
     _ctx: Context,
     { chatId }: TriggerContext,
-    _dialogue: DialogueManager
+    dialogue: DialogueManager
   ): Promise<TriggerResult | null> {
+    if (dialogue.isActive(chatId)) {
+      return null;
+    }
+
     const result = await this.checker.check(chatId);
     if (result) {
       logger.debug({ chatId }, 'Interest trigger matched');

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -11,7 +11,7 @@ import { InterestTrigger } from '../src/triggers/InterestTrigger';
 import { TriggerContext } from '../src/triggers/Trigger.interface';
 
 class MockInterestChecker implements InterestChecker {
-  private count = 0;
+  public calls = 0;
   constructor(
     private readonly n: number,
     private readonly result: {
@@ -26,8 +26,8 @@ class MockInterestChecker implements InterestChecker {
     message: string;
     why: string;
   } | null> {
-    this.count += 1;
-    if (this.count < this.n) {
+    this.calls += 1;
+    if (this.calls < this.n) {
       return null;
     }
     return this.result;
@@ -85,5 +85,25 @@ describe('InterestTrigger', () => {
       dialogue
     );
     expect(res).toBeNull();
+  });
+
+  it('skips interest check when dialogue is active', async () => {
+    const checker = new MockInterestChecker(1, {
+      messageId: '1',
+      message: 'hi',
+      why: 'because',
+    });
+    const trigger = new InterestTrigger(checker);
+    const activeDialogue: DialogueManager = new DefaultDialogueManager(
+      new TestEnvService()
+    );
+    activeDialogue.start(baseCtx.chatId);
+    const res = await trigger.apply(
+      {} as unknown as Context,
+      baseCtx,
+      activeDialogue
+    );
+    expect(res).toBeNull();
+    expect(checker.calls).toBe(0);
   });
 });

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -95,4 +95,33 @@ describe('TriggerPipeline', () => {
     res = await pipeline.shouldRespond(ctx, context);
     expect(res).not.toBeNull();
   });
+
+  it('skips interest trigger when dialogue is active', async () => {
+    const interestChecker: InterestChecker = {
+      check: vi.fn().mockResolvedValue({
+        messageId: '1',
+        message: 'hi',
+        why: 'because',
+      }),
+    };
+    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
+      env,
+      interestChecker,
+      dialogue
+    );
+    dialogue.start(1);
+    const ctx = {
+      message: { text: 'hello there' },
+      me: 'bot',
+    } as unknown as Context;
+    const context: TriggerContext = {
+      text: 'hello there',
+      replyText: '',
+      chatId: 1,
+    };
+    const res = await pipeline.shouldRespond(ctx, context);
+    expect(res).toBeNull();
+    expect(interestChecker.check).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- return early from interest trigger when dialogue is active
- skip invoking interest trigger in pipeline for active dialogues
- test active dialogues blocking interest trigger

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689df84be51c832782f54f2498641392