### PR TITLE
Ensure dialogues extend only when triggers match

### DIFF
--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -64,10 +64,12 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     }
 
     const matched = !!result;
-    if (matched && !inDialogue) {
-      this.dialogue.start(chatId);
-    } else if (!matched && inDialogue) {
-      this.dialogue.extend(chatId);
+    if (matched) {
+      if (inDialogue) {
+        this.dialogue.extend(chatId);
+      } else {
+        this.dialogue.start(chatId);
+      }
     }
 
     return result;

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -124,4 +124,30 @@ describe('TriggerPipeline', () => {
     expect(res).toBeNull();
     expect(interestChecker.check).not.toHaveBeenCalled();
   });
+
+  it('does not extend dialogue timer when no triggers match', async () => {
+    const interestChecker: InterestChecker = {
+      check: vi.fn().mockResolvedValue(null),
+    };
+    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
+      env,
+      interestChecker,
+      dialogue
+    );
+    const ctx = {
+      message: { text: 'hello there' },
+      me: 'bot',
+    } as unknown as Context;
+    const context: TriggerContext = {
+      text: 'hello there',
+      replyText: '',
+      chatId: 1,
+    };
+    dialogue.start(1);
+    const extendSpy = vi.spyOn(dialogue, 'extend');
+    const res = await pipeline.shouldRespond(ctx, context);
+    expect(res).toBeNull();
+    expect(extendSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Refine trigger pipeline to start or extend dialogue only when a trigger matches
- Add unit test covering that timer isn't extended without a trigger match

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dfb9fb1688327b17edffeec233ac7