### PR TITLE
Add admin main menu and actions

### DIFF
--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -101,7 +101,7 @@ describe('TelegramBot', () => {
     );
   });
 
-  it('shows admin menu with chats', async () => {
+  it('shows admin chats menu', async () => {
     const memories = new MockChatMemoryManager();
     const configureSpy = vi
       .spyOn(
@@ -129,8 +129,8 @@ describe('TelegramBot', () => {
     const ctx = { reply: vi.fn() } as unknown as Context;
 
     await (
-      bot as unknown as { showAdminMenu: (ctx: Context) => Promise<void> }
-    ).showAdminMenu(ctx);
+      bot as unknown as { showAdminChatsMenu: (ctx: Context) => Promise<void> }
+    ).showAdminChatsMenu(ctx);
 
     expect(approvalService.listAll).toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith('Выберите чат для управления:', {


### PR DESCRIPTION
## Summary
- add admin main menu with export and chat management options
- allow reusing export logic for admin and regular users
- expose chat list through dedicated admin menu

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dfd6a743c8327af450cba0d0fe709