### PR TITLE
Add window router and config for menu navigation

### DIFF
--- a/src/bot/windowConfig.ts
+++ b/src/bot/windowConfig.ts
@@ -1,0 +1,47 @@
+interface WindowButton {
+  text: string;
+  callback: string;
+  target?: string;
+  action?: string;
+}
+
+export interface WindowDefinition {
+  id: string;
+  text: string;
+  buttons: WindowButton[];
+}
+
+export const windows: WindowDefinition[] = [
+  {
+    id: 'main',
+    text: 'Выберите действие:',
+    buttons: [
+      {
+        text: '📊 Загрузить данные',
+        callback: 'export_data',
+        action: 'exportData',
+      },
+      {
+        text: '🔄 Сбросить память',
+        callback: 'reset_memory',
+        action: 'resetMemory',
+      },
+    ],
+  },
+  {
+    id: 'admin_main',
+    text: 'Выберите действие:',
+    buttons: [
+      {
+        text: '📊 Загрузить данные',
+        callback: 'admin_export_data',
+        action: 'exportData',
+      },
+      {
+        text: '💬 Чаты',
+        callback: 'admin_chats',
+        action: 'showAdminChatsMenu',
+      },
+    ],
+  },
+];

--- a/src/bot/windowRouter.ts
+++ b/src/bot/windowRouter.ts
@@ -1,0 +1,49 @@
+import type { Context, Telegraf } from 'telegraf';
+
+import type { WindowDefinition } from './windowConfig';
+
+type ActionHandlers = Record<string, (ctx: Context) => Promise<void> | void>;
+
+export class WindowRouter {
+  constructor(
+    private readonly bot: Telegraf<Context>,
+    private readonly windows: WindowDefinition[],
+    private readonly actions: ActionHandlers
+  ) {
+    this.register();
+  }
+
+  private register() {
+    for (const window of this.windows) {
+      for (const button of window.buttons) {
+        this.bot.action(button.callback, async (ctx) => {
+          const action = button.action
+            ? this.actions[button.action]
+            : undefined;
+          if (action) {
+            await action(ctx);
+          }
+          if (button.target) {
+            await this.showWindow(ctx, button.target);
+          }
+          await ctx.answerCbQuery().catch(() => {});
+        });
+      }
+    }
+  }
+
+  async showWindow(ctx: Context, id: string): Promise<void> {
+    const window = this.windows.find((w) => w.id === id);
+    if (!window) {
+      return;
+    }
+
+    const keyboard = window.buttons.map((b) => [
+      { text: b.text, callback_data: b.callback },
+    ]);
+
+    await ctx.reply(window.text, {
+      reply_markup: { inline_keyboard: keyboard },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- define menu windows and buttons for the bot
- add a reusable window router to show windows and trigger actions
- wire TelegramBot to use the router and reset-memory handler

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e0562f4b483278aa16625a79715c6