### PR TITLE
refactor: centralize menu display through WindowRouter

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -255,7 +255,7 @@ export class TelegramBot {
     assert(chatId, 'This is not a chat');
 
     if (chatId === this.env.ADMIN_CHAT_ID) {
-      await this.router.show(ctx, 'admin_main');
+      await this.router.show(ctx, 'admin_menu');
       return;
     }
 
@@ -289,7 +289,7 @@ export class TelegramBot {
       return;
     }
 
-    await this.router.show(ctx, 'main');
+    await this.router.show(ctx, 'menu');
   }
 
   private async showAdminChatsMenu(ctx: Context) {

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -74,6 +74,8 @@ export class TelegramBot {
       exportData: (ctx) => this.handleExportData(ctx),
       resetMemory: (ctx) => this.handleResetMemory(ctx),
       showAdminChatsMenu: (ctx) => this.showAdminChatsMenu(ctx),
+      requestChatAccess: (ctx) => this.handleChatRequest(ctx),
+      requestUserAccess: (ctx) => this.handleRequestAccess(ctx),
     });
     this.configure();
   }
@@ -96,52 +98,8 @@ export class TelegramBot {
           { chatId, status },
           'Chat not approved, showing request access button'
         );
-        await ctx.reply('Этот чат не находится в списке разрешённых.', {
-          reply_markup: {
-            inline_keyboard: [
-              [{ text: 'Запросить доступ', callback_data: 'chat_request' }],
-            ],
-          },
-        });
+        await this.router.show(ctx, 'chat_not_approved');
       }
-    });
-
-    this.bot.action('chat_request', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      assert(chatId, 'This is not a chat');
-      const title = 'title' in ctx.chat! ? ctx.chat.title : undefined;
-      logger.info({ chatId, title }, 'Chat access request received');
-      await this.sendChatApprovalRequest(chatId, title);
-
-      await ctx.answerCbQuery();
-      await ctx.reply('Запрос отправлен');
-      logger.info({ chatId }, 'Chat access request sent to admin');
-    });
-
-    this.bot.action('request_access', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      const userId = ctx.from?.id;
-      assert(chatId, 'This is not a chat');
-      assert(userId, 'No user id');
-      const firstName = ctx.from?.first_name;
-      const lastName = ctx.from?.last_name;
-      const username = ctx.from?.username;
-      const fullName = [firstName, lastName].filter(Boolean).join(' ');
-      const usernamePart = username ? ` @${username}` : '';
-      const approveData = `user_approve:${chatId}:${userId}`;
-      const msg = `Chat ${chatId} user ${userId} (${fullName}${usernamePart}) requests data access.`;
-      await ctx.telegram.sendMessage(this.env.ADMIN_CHAT_ID, msg, {
-        reply_markup: {
-          inline_keyboard: [
-            [
-              { text: 'Одобрить', callback_data: approveData },
-              { text: 'Забанить чат', callback_data: `chat_ban:${chatId}` },
-            ],
-          ],
-        },
-      });
-      await ctx.answerCbQuery();
-      await ctx.reply('Запрос отправлен администратору.');
     });
 
     // Обработчики кнопок навигации и действий регистрируются в WindowRouter
@@ -265,13 +223,7 @@ export class TelegramBot {
       return;
     }
     if (status !== 'approved') {
-      await ctx.reply('Этот чат не находится в списке разрешённых.', {
-        reply_markup: {
-          inline_keyboard: [
-            [{ text: 'Запросить доступ', callback_data: 'chat_request' }],
-          ],
-        },
-      });
+      await this.router.show(ctx, 'chat_not_approved');
       return;
     }
 
@@ -279,13 +231,7 @@ export class TelegramBot {
     if (!userId) return;
     const allowed = await this.admin.hasAccess(chatId, userId);
     if (!allowed) {
-      await ctx.reply('Для работы с данными нужен доступ.', {
-        reply_markup: {
-          inline_keyboard: [
-            [{ text: '🔑 Запросить доступ', callback_data: 'request_access' }],
-          ],
-        },
-      });
+      await this.router.show(ctx, 'no_access');
       return;
     }
 
@@ -315,6 +261,41 @@ export class TelegramBot {
     await ctx.reply('Выберите чат для управления:', {
       reply_markup: { inline_keyboard: keyboard },
     });
+  }
+
+  private async handleChatRequest(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    assert(chatId, 'This is not a chat');
+    const title = 'title' in ctx.chat! ? ctx.chat.title : undefined;
+    logger.info({ chatId, title }, 'Chat access request received');
+    await this.sendChatApprovalRequest(chatId, title);
+    await ctx.reply('Запрос отправлен');
+    logger.info({ chatId }, 'Chat access request sent to admin');
+  }
+
+  private async handleRequestAccess(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    const userId = ctx.from?.id;
+    assert(chatId, 'This is not a chat');
+    assert(userId, 'No user id');
+    const firstName = ctx.from?.first_name;
+    const lastName = ctx.from?.last_name;
+    const username = ctx.from?.username;
+    const fullName = [firstName, lastName].filter(Boolean).join(' ');
+    const usernamePart = username ? ` @${username}` : '';
+    const approveData = `user_approve:${chatId}:${userId}`;
+    const msg = `Chat ${chatId} user ${userId} (${fullName}${usernamePart}) requests data access.`;
+    await ctx.telegram.sendMessage(this.env.ADMIN_CHAT_ID, msg, {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: 'Одобрить', callback_data: approveData },
+            { text: 'Забанить чат', callback_data: `chat_ban:${chatId}` },
+          ],
+        ],
+      },
+    });
+    await ctx.reply('Запрос отправлен администратору.');
   }
 
   private async handleExportData(ctx: Context) {

--- a/src/bot/windowConfig.ts
+++ b/src/bot/windowConfig.ts
@@ -13,7 +13,7 @@ export interface WindowDefinition {
 
 export const windows: WindowDefinition[] = [
   {
-    id: 'main',
+    id: 'menu',
     text: 'Выберите действие:',
     buttons: [
       {
@@ -29,7 +29,7 @@ export const windows: WindowDefinition[] = [
     ],
   },
   {
-    id: 'admin_main',
+    id: 'admin_menu',
     text: 'Выберите действие:',
     buttons: [
       {

--- a/src/bot/windowConfig.ts
+++ b/src/bot/windowConfig.ts
@@ -44,4 +44,26 @@ export const windows: WindowDefinition[] = [
       },
     ],
   },
+  {
+    id: 'chat_not_approved',
+    text: 'Этот чат не находится в списке разрешённых.',
+    buttons: [
+      {
+        text: 'Запросить доступ',
+        callback: 'chat_request',
+        action: 'requestChatAccess',
+      },
+    ],
+  },
+  {
+    id: 'no_access',
+    text: 'Для работы с данными нужен доступ.',
+    buttons: [
+      {
+        text: '🔑 Запросить доступ',
+        callback: 'request_access',
+        action: 'requestUserAccess',
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- use `menu`/`admin_menu` IDs for window configuration
- route menu display through `WindowRouter`

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e0a270d648327a4f1fc5d694debb5