### PR TITLE
Add WindowRouter tests and document windowConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ npm run lint:fix
 - Сервисы определяются через интерфейсы и Symbol-ключи Inversify; реализации
   привязываются в `src/container.ts`.
 
+### WindowRouter и windowConfig
+
+В `windowConfig` описываются окна меню и их кнопки:
+
+```ts
+interface WindowDefinition {
+  id: string; // уникальный идентификатор окна
+  text: string; // текст сообщения
+  buttons: Array<{
+    text: string; // подпись кнопки
+    callback: string; // значение callback_data
+    target?: string; // id окна для перехода
+    action?: string; // имя обработчика
+  }>;
+}
+```
+
+`WindowRouter` регистрирует обработчики `callback_data`, показывает окна и
+управляет стеком переходов. При навигации предыдущее сообщение удаляется, а при
+наличии истории автоматически добавляется кнопка «⬅️ Назад». Для показа окна
+используйте `router.show(ctx, id)` и передавайте словарь действий при создании
+экземпляра `WindowRouter`.
+
 ### Структура БД
 
 В SQLite используются следующие основные таблицы:

--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -1,0 +1,110 @@
+import type { Context } from 'telegraf';
+import { Telegraf } from 'telegraf';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WindowDefinition } from '../../src/bot/windowConfig';
+import { WindowRouter } from '../../src/bot/WindowRouter';
+
+const windows: WindowDefinition[] = [
+  {
+    id: 'first',
+    text: 'First window',
+    buttons: [{ text: 'Next', callback: 'to_second', target: 'second' }],
+  },
+  { id: 'second', text: 'Second window', buttons: [] },
+];
+
+function setupRouter() {
+  const bot = new Telegraf<Context>('token');
+  const actionSpy = vi.spyOn(bot, 'action');
+  new WindowRouter(
+    bot,
+    windows,
+    {} as Record<string, (ctx: Context) => Promise<void> | void>
+  );
+  const goHandler = actionSpy.mock.calls.find(
+    ([pattern]) => pattern === 'to_second'
+  )![1];
+  const backHandler = actionSpy.mock.calls.find(
+    ([pattern]) => pattern === 'back'
+  )![1];
+  actionSpy.mockRestore();
+  return { goHandler, backHandler };
+}
+
+describe('WindowRouter', () => {
+  it('transitions between windows and back', async () => {
+    const { goHandler, backHandler } = setupRouter();
+    const ctx = {
+      chat: { id: 1 },
+      callbackQuery: { message: { message_id: 10 } },
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
+      answerCbQuery: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await goHandler(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('Second window', {
+      reply_markup: {
+        inline_keyboard: [[{ text: '⬅️ Назад', callback_data: 'back' }]],
+      },
+    });
+
+    const ctxBack = {
+      chat: { id: 1 },
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
+      answerCbQuery: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await backHandler(ctxBack);
+    expect(ctxBack.reply).toHaveBeenCalledWith('First window', {
+      reply_markup: {
+        inline_keyboard: [[{ text: 'Next', callback_data: 'to_second' }]],
+      },
+    });
+  });
+
+  it('adds back button when history exists', async () => {
+    const { goHandler } = setupRouter();
+    const ctx = {
+      chat: { id: 1 },
+      callbackQuery: { message: { message_id: 11 } },
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
+      answerCbQuery: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await goHandler(ctx);
+
+    expect(ctx.reply).toHaveBeenCalledWith('Second window', {
+      reply_markup: {
+        inline_keyboard: [[{ text: '⬅️ Назад', callback_data: 'back' }]],
+      },
+    });
+  });
+
+  it('deletes messages on navigation and back', async () => {
+    const { goHandler, backHandler } = setupRouter();
+    const ctx = {
+      chat: { id: 1 },
+      callbackQuery: { message: { message_id: 12 } },
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
+      answerCbQuery: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await goHandler(ctx);
+    expect(ctx.deleteMessage).toHaveBeenCalled();
+
+    const ctxBack = {
+      chat: { id: 1 },
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
+      answerCbQuery: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await backHandler(ctxBack);
+    expect(ctxBack.deleteMessage).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for window navigation, back button and message cleanup
- document `windowConfig` structure and `WindowRouter` usage

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e113cce94832786923eef59365091