### PR TITLE
test: expand TelegramBot coverage

### DIFF
--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -36,7 +36,7 @@ import { TriggerContext } from '../triggers/Trigger.interface';
 import { windows } from './windowConfig';
 import { WindowRouter } from './WindowRouter';
 
-async function withTyping(ctx: Context, fn: () => Promise<void>) {
+export async function withTyping(ctx: Context, fn: () => Promise<void>) {
   await ctx.sendChatAction('typing');
 
   const timer = setInterval(() => {


### PR DESCRIPTION
## Summary
- exercise chat request flow and user access approvals
- cover export and reset memory scenarios, including error cases
- verify typing indicator behavior via exported helper

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e46eeb7d883278bdf9ece9e9b0c3b