### PR TITLE
Adjust coverage thresholds to current levels

### DIFF
--- a/test/AdminServiceImpl.test.ts
+++ b/test/AdminServiceImpl.test.ts
@@ -2,6 +2,7 @@ import type { Database } from 'sqlite';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { DbProvider } from '../src/repositories/DbProvider';
+import type { AccessKeyRepository } from '../src/repositories/interfaces/AccessKeyRepository.interface';
 import type { ChatUserRepository } from '../src/repositories/interfaces/ChatUserRepository.interface';
 import type { MessageRepository } from '../src/repositories/interfaces/MessageRepository.interface';
 import type { SummaryRepository } from '../src/repositories/interfaces/SummaryRepository.interface';
@@ -9,6 +10,72 @@ import type { UserRepository } from '../src/repositories/interfaces/UserReposito
 import { AdminServiceImpl } from '../src/services/admin/AdminServiceImpl';
 
 describe('AdminServiceImpl', () => {
+  it('creates access key and returns expiry date', async () => {
+    const accessRepo = {
+      upsertKey: vi.fn(),
+      deleteExpired: vi.fn(),
+      findByChatAndUser: vi.fn(),
+    } as unknown as AccessKeyRepository;
+    const admin = new AdminServiceImpl(
+      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider<Database>,
+      accessRepo,
+      {} as unknown as MessageRepository,
+      {} as unknown as SummaryRepository,
+      {} as unknown as ChatUserRepository,
+      {} as unknown as UserRepository
+    );
+    const expires = await admin.createAccessKey(1, 2, 1000);
+    expect(accessRepo.upsertKey).toHaveBeenCalledWith({
+      chatId: 1,
+      userId: 2,
+      accessKey: expect.any(String),
+      expiresAt: expect.any(Number),
+    });
+    expect(expires).toBeInstanceOf(Date);
+  });
+
+  it('checks access by deleting expired keys and finding entry', async () => {
+    const accessRepo = {
+      deleteExpired: vi.fn(),
+      findByChatAndUser: vi.fn(async () => ({ chatId: 1, userId: 2 })),
+    } as unknown as AccessKeyRepository;
+    const admin = new AdminServiceImpl(
+      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider<Database>,
+      accessRepo,
+      {} as unknown as MessageRepository,
+      {} as unknown as SummaryRepository,
+      {} as unknown as ChatUserRepository,
+      {} as unknown as UserRepository
+    );
+    expect(await admin.hasAccess(1, 2)).toBe(true);
+    expect(accessRepo.deleteExpired).toHaveBeenCalled();
+    accessRepo.findByChatAndUser = vi.fn(async () => undefined);
+    expect(await admin.hasAccess(1, 2)).toBe(false);
+  });
+
+  it('exports all database tables', async () => {
+    const dbAll = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }])
+      .mockResolvedValueOnce([]);
+    const db = { all: dbAll } as unknown as Database;
+    const provider = {
+      get: vi.fn(async () => db),
+      listTables: vi.fn(async () => ['t']),
+    } as unknown as DbProvider<Database>;
+    const admin = new AdminServiceImpl(
+      provider,
+      {} as unknown as AccessKeyRepository,
+      {} as unknown as MessageRepository,
+      {} as unknown as SummaryRepository,
+      {} as unknown as ChatUserRepository,
+      {} as unknown as UserRepository
+    );
+    const files = await admin.exportTables();
+    expect(files).toEqual([{ filename: 't.csv', buffer: expect.any(Buffer) }]);
+    expect(dbAll).toHaveBeenCalled();
+  });
+
   it('exports chat messages, summaries and users', async () => {
     const messageRepo = {
       findByChatId: vi.fn(async () => [

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -199,6 +199,38 @@ describe('ChatGPTService', () => {
     });
   });
 
+  it('ask without optional params and summarize without prev', async () => {
+    openaiCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'resp' } }],
+    });
+    const resAsk = await service.ask([]);
+    expect(resAsk).toBe('resp');
+    expect(openaiCreate).toHaveBeenCalledWith({
+      model: env.getModels().ask,
+      messages: [
+        { role: 'system', content: 'persona' },
+        { role: 'system', content: 'priority' },
+        { role: 'system', content: 'userSystem' },
+      ],
+    });
+
+    openaiCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'sum' } }],
+    });
+    const resSum = await service.summarize([]);
+    expect(resSum).toBe('sum');
+    expect(openaiCreate).toHaveBeenCalledWith({
+      model: env.getModels().summary,
+      messages: [
+        { role: 'system', content: 'sumSystem' },
+        {
+          role: 'user',
+          content: 'История диалога:\n',
+        },
+      ],
+    });
+  });
+
   it('logPrompt writes only when LOG_PROMPTS=true', async () => {
     openaiCreate.mockResolvedValue({
       choices: [{ message: { content: 'r' } }],

--- a/test/InterestChecker.test.ts
+++ b/test/InterestChecker.test.ts
@@ -86,4 +86,18 @@ describe('DefaultInterestChecker', () => {
     const res = await checker.check(chatId);
     expect(res).toBeNull();
   });
+
+  it('uses empty message when ID not found', async () => {
+    const history: ChatMessage[] = [
+      { role: 'user', content: 'msg1', messageId: 1 },
+    ];
+    const { checker } = createChecker({
+      count: 2,
+      history,
+      summary: '',
+      aiResult: { messageId: '42', why: 'w' },
+    });
+    const res = await checker.check(chatId);
+    expect(res).toEqual({ messageId: '42', message: '', why: 'w' });
+  });
 });

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -42,6 +42,18 @@ describe('MentionTrigger', () => {
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
+
+  it('handles non-string fields gracefully', async () => {
+    const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
+    const telegrafCtx = { message: {}, me: undefined } as unknown as Context;
+    const res = await trigger.apply(
+      telegrafCtx,
+      ctx,
+      new DefaultDialogueManager(new TestEnvService())
+    );
+    expect(res).toBeNull();
+    expect(ctx.text).toBe('');
+  });
 });
 
 describe('NameTrigger', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: 'v8',
-      thresholds: { lines: 60, functions: 65, branches: 80 },
+      thresholds: { lines: 86.55, functions: 84.21, branches: 84.52 },
       include: ['src/**/*.ts'],
       exclude: [
         'dist/**',


### PR DESCRIPTION
## Summary
- remove recently added coverage exclusions for bot and AI directories
- set coverage thresholds to match existing coverage levels

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e4c3945588327993981a8f4663819