### PR TITLE
Enforce consistent TypeScript member ordering

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -37,6 +37,27 @@ module.exports = [
           argsIgnorePattern: '^_',
         },
       ],
+      '@typescript-eslint/member-ordering': [
+        'error',
+        {
+          default: [
+            'signature',
+            'public-static-field',
+            'protected-static-field',
+            'private-static-field',
+            'public-static-method',
+            'protected-static-method',
+            'private-static-method',
+            'public-instance-field',
+            'protected-instance-field',
+            'private-instance-field',
+            'constructor',
+            'public-instance-method',
+            'protected-instance-method',
+            'private-instance-method',
+          ],
+        },
+      ],
       'import/no-unused-modules': [
         'error',
         {

--- a/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
+++ b/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
@@ -9,11 +9,6 @@ import {
 @injectable()
 export class SQLiteAccessKeyRepository implements AccessKeyRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async upsertKey({
     chatId,
     userId,
@@ -58,5 +53,9 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
   async deleteExpired(now: number): Promise<void> {
     const db = await this.db();
     await db.run('DELETE FROM access_keys WHERE expires_at <= ?', now);
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatAccessRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatAccessRepository.ts
@@ -10,11 +10,6 @@ import {
 @injectable()
 export class SQLiteChatAccessRepository implements ChatAccessRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async get(chatId: number): Promise<ChatAccessEntity | undefined> {
     const db = await this.db();
     const row = await db.get<{
@@ -87,5 +82,9 @@ export class SQLiteChatAccessRepository implements ChatAccessRepository {
       requestedAt: row.requested_at ?? undefined,
       approvedAt: row.approved_at ?? undefined,
     }));
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatRepository.ts
@@ -9,11 +9,6 @@ import {
 @injectable()
 export class SQLiteChatRepository implements ChatRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async upsert({ chatId, title }: ChatEntity): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -30,5 +25,9 @@ export class SQLiteChatRepository implements ChatRepository {
       chatId
     );
     return row ? { chatId: row.chat_id, title: row.title } : undefined;
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatUserRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatUserRepository.ts
@@ -6,11 +6,6 @@ import { type ChatUserRepository } from '../interfaces/ChatUserRepository.interf
 @injectable()
 export class SQLiteChatUserRepository implements ChatUserRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async link(chatId: number, userId: number): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -28,5 +23,9 @@ export class SQLiteChatUserRepository implements ChatUserRepository {
       }[]
     >('SELECT user_id FROM chat_users WHERE chat_id = ?', chatId);
     return (rows ?? []).map((row) => row.user_id);
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteMessageRepository.ts
+++ b/src/repositories/sqlite/SQLiteMessageRepository.ts
@@ -8,11 +8,6 @@ import { type MessageRepository } from '../interfaces/MessageRepository.interfac
 @injectable()
 export class SQLiteMessageRepository implements MessageRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async insert({
     chatId,
     messageId,
@@ -137,5 +132,9 @@ export class SQLiteMessageRepository implements MessageRepository {
   async clearByChatId(chatId: number): Promise<void> {
     const db = await this.db();
     await db.run('DELETE FROM messages WHERE chat_id = ?', chatId);
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteSummaryRepository.ts
+++ b/src/repositories/sqlite/SQLiteSummaryRepository.ts
@@ -6,11 +6,6 @@ import { type SummaryRepository } from '../interfaces/SummaryRepository.interfac
 @injectable()
 export class SQLiteSummaryRepository implements SummaryRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async upsert(chatId: number, summary: string): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -32,5 +27,9 @@ export class SQLiteSummaryRepository implements SummaryRepository {
   async clearByChatId(chatId: number): Promise<void> {
     const db = await this.db();
     await db.run('DELETE FROM summaries WHERE chat_id = ?', chatId);
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteUserRepository.ts
+++ b/src/repositories/sqlite/SQLiteUserRepository.ts
@@ -9,11 +9,6 @@ import {
 @injectable()
 export class SQLiteUserRepository implements UserRepository {
   constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
-
-  private async db() {
-    return this.dbProvider.get();
-  }
-
   async upsert({
     id,
     username,
@@ -62,5 +57,9 @@ export class SQLiteUserRepository implements UserRepository {
       attitude,
       userId
     );
+  }
+
+  private async db() {
+    return this.dbProvider.get();
   }
 }

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -33,27 +33,6 @@ export class ChatGPTService implements AIService {
     logger.debug('ChatGPTService initialized');
   }
 
-  private async logPrompt(
-    type: string,
-    messages: OpenAI.ChatCompletionMessageParam[],
-    response?: string
-  ): Promise<void> {
-    if (!this.envService.env.LOG_PROMPTS) {
-      return;
-    }
-    const filePath = path.join(process.cwd(), 'prompts.log');
-    const entry = `\n[${new Date().toISOString()}] ${type}\nPROMPT:\n${JSON.stringify(
-      messages,
-      null,
-      2
-    )}\n${response ? `RESPONSE:\n${response}\n` : ''}---\n`;
-    try {
-      await fs.appendFile(filePath, entry);
-    } catch (err) {
-      logger.error({ err }, 'Failed to write prompt log');
-    }
-  }
-
   public async ask(
     history: ChatMessage[],
     summary?: string,
@@ -279,5 +258,26 @@ export class ChatGPTService implements AIService {
     const response = completion.choices[0]?.message?.content ?? prev ?? '';
     void this.logPrompt('summary', messages, response);
     return response;
+  }
+
+  private async logPrompt(
+    type: string,
+    messages: OpenAI.ChatCompletionMessageParam[],
+    response?: string
+  ): Promise<void> {
+    if (!this.envService.env.LOG_PROMPTS) {
+      return;
+    }
+    const filePath = path.join(process.cwd(), 'prompts.log');
+    const entry = `\n[${new Date().toISOString()}] ${type}\nPROMPT:\n${JSON.stringify(
+      messages,
+      null,
+      2
+    )}\n${response ? `RESPONSE:\n${response}\n` : ''}---\n`;
+    try {
+      await fs.appendFile(filePath, entry);
+    } catch (err) {
+      logger.error({ err }, 'Failed to write prompt log');
+    }
   }
 }

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -23,18 +23,6 @@ export class DefaultDialogueManager implements DialogueManager {
     this.timeoutMs = envService.getDialogueTimeoutMs();
   }
 
-  private setTimer(chatId: number) {
-    const existing = this.timers.get(chatId);
-    if (existing) {
-      clearTimeout(existing);
-    }
-    const timer = setTimeout(() => {
-      this.timers.delete(chatId);
-      logger.debug({ chatId }, 'Dialogue timed out');
-    }, this.timeoutMs);
-    this.timers.set(chatId, timer);
-  }
-
   start(chatId: number) {
     logger.debug({ chatId }, 'Starting dialogue');
     this.setTimer(chatId);
@@ -47,5 +35,17 @@ export class DefaultDialogueManager implements DialogueManager {
 
   isActive(chatId: number): boolean {
     return this.timers.has(chatId);
+  }
+
+  private setTimer(chatId: number) {
+    const existing = this.timers.get(chatId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+    const timer = setTimeout(() => {
+      this.timers.delete(chatId);
+      logger.debug({ chatId }, 'Dialogue timed out');
+    }, this.timeoutMs);
+    this.timers.set(chatId, timer);
   }
 }


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/member-ordering` rule with standard ordering
- reorder class members across bot, repository, and service modules

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e51eb4a9c8327a842878e3b9bce4a