### PR TITLE
Forbid TypeScript non-null assertions and refactor code

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -19,6 +19,7 @@ module.exports = [
       'simple-import-sort/exports': 'error',
       'unused-imports/no-unused-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
       '@typescript-eslint/ban-ts-comment': [
         'error',
         {

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -38,9 +38,12 @@ import { WindowRouter } from './WindowRouter';
 
 export async function withTyping(ctx: Context, fn: () => Promise<void>) {
   await ctx.sendChatAction('typing');
+  const chatId = ctx.chat?.id;
 
   const timer = setInterval(() => {
-    ctx.telegram.sendChatAction(ctx.chat!.id, 'typing').catch(() => {});
+    if (chatId !== undefined) {
+      ctx.telegram.sendChatAction(chatId, 'typing').catch(() => {});
+    }
   }, 4000);
 
   try {
@@ -305,7 +308,7 @@ export class TelegramBot {
   private async handleChatRequest(ctx: Context) {
     const chatId = ctx.chat?.id;
     assert(chatId, 'This is not a chat');
-    const title = 'title' in ctx.chat! ? ctx.chat.title : undefined;
+    const title = ctx.chat && 'title' in ctx.chat ? ctx.chat.title : undefined;
     logger.info({ chatId, title }, 'Chat access request received');
     await this.sendChatApprovalRequest(chatId, title);
     await ctx.reply('Запрос отправлен');
@@ -419,7 +422,8 @@ export class TelegramBot {
 
     const status = await this.approvalService.getStatus(chatId);
     if (status === 'pending') {
-      const title = 'title' in ctx.chat! ? ctx.chat.title : undefined;
+      const title =
+        ctx.chat && 'title' in ctx.chat ? ctx.chat.title : undefined;
       await this.sendChatApprovalRequest(chatId, title);
 
       return;

--- a/src/services/messages/MessageFactory.ts
+++ b/src/services/messages/MessageFactory.ts
@@ -15,6 +15,11 @@ export class MessageFactory {
 
     const { replyText, replyUsername, quoteText, username, fullName } = meta;
 
+    const chatId = ctx.chat?.id;
+    assert(chatId, 'No chat id');
+    const chatTitle =
+      ctx.chat && 'title' in ctx.chat ? ctx.chat.title : undefined;
+
     return {
       role: 'user',
       content: message.text,
@@ -27,18 +32,23 @@ export class MessageFactory {
       messageId: ctx.message?.message_id,
       firstName: ctx.from?.first_name,
       lastName: ctx.from?.last_name,
-      chatId: ctx.chat!.id,
-      chatTitle: 'title' in ctx.chat! ? ctx.chat.title : undefined,
+      chatId,
+      chatTitle,
     };
   }
 
   static fromAssistant(ctx: Context, content: string): StoredMessage {
+    const chatId = ctx.chat?.id;
+    assert(chatId, 'No chat id');
+    const chatTitle =
+      ctx.chat && 'title' in ctx.chat ? ctx.chat.title : undefined;
+
     return {
       role: 'assistant',
       content,
       username: ctx.me,
-      chatId: ctx.chat!.id,
-      chatTitle: 'title' in ctx.chat! ? ctx.chat.title : undefined,
+      chatId,
+      chatTitle,
     };
   }
 }

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -178,7 +178,10 @@ describe('TelegramBot', () => {
         pattern instanceof RegExp && pattern.source === '^admin_chat:(\\S+)$'
     );
     actionSpy.mockRestore();
-    const handler = call![1];
+    if (!call) {
+      throw new Error('Handler not found');
+    }
+    const handler = call[1];
 
     const ctx = {
       chat: { id: 1 },
@@ -218,7 +221,10 @@ describe('TelegramBot', () => {
         pattern instanceof RegExp && pattern.source === '^chat_ban:(\\S+)$'
     );
     actionSpy.mockRestore();
-    const handler = call![1];
+    if (!call) {
+      throw new Error('Handler not found');
+    }
+    const handler = call[1];
 
     const ctx = {
       chat: { id: 1 },
@@ -355,7 +361,10 @@ describe('TelegramBot', () => {
         pattern.source === '^user_approve:(\\S+):(\\S+)$'
     );
     actionSpy.mockRestore();
-    const handler = call![1];
+    if (!call) {
+      throw new Error('Handler not found');
+    }
+    const handler = call[1];
 
     const ctx = {
       chat: { id: 1 },
@@ -815,7 +824,7 @@ describe('TelegramBot', () => {
     await vi.advanceTimersByTimeAsync(4000);
     expect(ctx.telegram.sendChatAction).toHaveBeenCalledWith(1, 'typing');
 
-    resolveFn!();
+    resolveFn?.();
     await promise;
 
     await vi.advanceTimersByTimeAsync(4000);

--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -22,13 +22,16 @@ function setupRouter() {
     windows,
     {} as Record<string, (ctx: Context) => Promise<void> | void>
   );
-  const goHandler = actionSpy.mock.calls.find(
+  const goCall = actionSpy.mock.calls.find(
     ([pattern]) => pattern === 'to_second'
-  )![1];
-  const backHandler = actionSpy.mock.calls.find(
-    ([pattern]) => pattern === 'back'
-  )![1];
+  );
+  const backCall = actionSpy.mock.calls.find(([pattern]) => pattern === 'back');
   actionSpy.mockRestore();
+  if (!goCall || !backCall) {
+    throw new Error('Handlers not registered');
+  }
+  const goHandler = goCall[1];
+  const backHandler = backCall[1];
   return { router, goHandler, backHandler };
 }
 


### PR DESCRIPTION
## Summary
- enforce `@typescript-eslint/no-non-null-assertion` lint rule
- replace non-null assertions with safe checks in bot, message factory, and tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e53fd4ac88327a8612dd03ebd907c