### PR TITLE
chore: enforce type-only imports

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -19,6 +19,7 @@ module.exports = [
       'simple-import-sort/exports': 'error',
       'unused-imports/no-unused-imports': 'error',
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/ban-ts-comment': [
         'error',
         {

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -2,13 +2,18 @@ import { promises as fs } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ChatMessage } from '../src/services/ai/AIService';
+import type { ChatGPTService as ChatGPTServiceType } from '../src/services/ai/ChatGPTService';
 import { TestEnvService } from '../src/services/env/EnvService';
 import { logger } from '../src/services/logging/logger';
 import type { PromptService } from '../src/services/prompts/PromptService';
 
+interface ChatGPTServiceConstructor {
+  new (env: TestEnvService, prompts: PromptService): ChatGPTServiceType;
+}
+
 describe('ChatGPTService', () => {
-  let ChatGPTService: typeof import('../src/services/ai/ChatGPTService').ChatGPTService;
-  let service: import('../src/services/ai/ChatGPTService').ChatGPTService;
+  let ChatGPTService: ChatGPTServiceConstructor;
+  let service: ChatGPTServiceType;
   let openaiCreate: ReturnType<typeof vi.fn<[], unknown>>;
   let prompts: Record<string, unknown>;
   let env: TestEnvService;

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, writeFileSync } from 'fs';
+import type * as fsPromises from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -69,8 +70,7 @@ describe('FilePromptService', () => {
       'trigger {{triggerReason}} {{triggerMessage}}'
     );
 
-    const actual =
-      await vi.importActual<typeof import('fs/promises')>('fs/promises');
+    const actual = await vi.importActual<typeof fsPromises>('fs/promises');
     readFileSpy = vi.fn(actual.readFile);
     vi.doMock('fs/promises', () => ({ ...actual, readFile: readFileSpy }));
 


### PR DESCRIPTION
## Summary
- add `@typescript-eslint/consistent-type-imports` rule
- update tests to use type-only imports

## Testing
- `npx eslint eslint.config.cjs test/ChatGPTService.test.ts test/PromptService.test.ts --fix`
- `npx prettier eslint.config.cjs test/ChatGPTService.test.ts test/PromptService.test.ts --write`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e549ed3d48327bf2206e091603763