### PR TITLE
Enforce explicit function return types

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -37,6 +37,10 @@ module.exports = [
           argsIgnorePattern: '^_',
         },
       ],
+      '@typescript-eslint/explicit-function-return-type': [
+        'error',
+        { allowExpressions: true, allowTypedFunctionExpressions: true },
+      ],
       '@typescript-eslint/member-ordering': [
         'error',
         {

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -36,7 +36,10 @@ import { TriggerContext } from '../triggers/Trigger.interface';
 import { windows } from './windowConfig';
 import { WindowRouter } from './WindowRouter';
 
-export async function withTyping(ctx: Context, fn: () => Promise<void>) {
+export async function withTyping(
+  ctx: Context,
+  fn: () => Promise<void>
+): Promise<void> {
   await ctx.sendChatAction('typing');
 
   const timer = setInterval(() => {
@@ -80,7 +83,7 @@ export class TelegramBot {
     this.configure();
   }
 
-  public async launch() {
+  public async launch(): Promise<void> {
     logger.info('Launching bot');
     await this.bot.telegram
       .deleteWebhook()
@@ -91,7 +94,7 @@ export class TelegramBot {
     logger.info('Bot launched');
   }
 
-  public stop(reason: string) {
+  public stop(reason: string): void {
     logger.info({ reason }, 'Stopping bot');
     this.bot.stop(reason);
   }
@@ -119,7 +122,7 @@ export class TelegramBot {
     );
   }
 
-  private configure() {
+  private configure(): void {
     this.bot.start((ctx) => this.showMenu(ctx));
     this.bot.command('menu', (ctx) => this.showMenu(ctx));
 
@@ -247,7 +250,7 @@ export class TelegramBot {
     this.bot.on(message('text'), (ctx) => this.handleText(ctx));
   }
 
-  private async showMenu(ctx: Context) {
+  private async showMenu(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     assert(chatId, 'This is not a chat');
 
@@ -277,7 +280,7 @@ export class TelegramBot {
     await this.router.show(ctx, 'menu');
   }
 
-  private async showAdminChatsMenu(ctx: Context) {
+  private async showAdminChatsMenu(ctx: Context): Promise<void> {
     const chats = await this.approvalService.listAll();
     if (chats.length === 0) {
       await ctx.reply('Нет чатов для управления');
@@ -302,7 +305,7 @@ export class TelegramBot {
     });
   }
 
-  private async handleChatRequest(ctx: Context) {
+  private async handleChatRequest(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     assert(chatId, 'This is not a chat');
     const title = 'title' in ctx.chat! ? ctx.chat.title : undefined;
@@ -312,7 +315,7 @@ export class TelegramBot {
     logger.info({ chatId }, 'Chat access request sent to admin');
   }
 
-  private async handleRequestAccess(ctx: Context) {
+  private async handleRequestAccess(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     const userId = ctx.from?.id;
     assert(chatId, 'This is not a chat');
@@ -337,7 +340,7 @@ export class TelegramBot {
     await ctx.reply('Запрос отправлен администратору.');
   }
 
-  private async handleExportData(ctx: Context) {
+  private async handleExportData(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     const userId = ctx.from?.id;
     assert(chatId, 'This is not a chat');
@@ -382,7 +385,7 @@ export class TelegramBot {
     }
   }
 
-  private async handleResetMemory(ctx: Context) {
+  private async handleResetMemory(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     const userId = ctx.from?.id;
     assert(chatId, 'This is not a chat');
@@ -407,7 +410,7 @@ export class TelegramBot {
     }
   }
 
-  private async handleText(ctx: Context) {
+  private async handleText(ctx: Context): Promise<void> {
     const chatId = ctx.chat?.id;
     assert(!!chatId, 'This is not a chat');
     if (chatId === this.env.ADMIN_CHAT_ID) {

--- a/src/bot/WindowRouter.ts
+++ b/src/bot/WindowRouter.ts
@@ -50,7 +50,7 @@ export class WindowRouter {
     });
   }
 
-  private register() {
+  private register(): void {
     for (const window of this.windows) {
       for (const button of window.buttons) {
         this.bot.action(button.callback, async (ctx) => {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -43,7 +43,7 @@ async function getDb(): Promise<SqliteDatabase> {
 
 type SqliteDatabase = Database<sqlite3.Database, sqlite3.Statement>;
 
-async function ensureTable(db: SqliteDatabase) {
+async function ensureTable(db: SqliteDatabase): Promise<void> {
   logger.debug('Checking for migrations table');
   await db.run(
     'CREATE TABLE IF NOT EXISTS migrations (id TEXT PRIMARY KEY, applied_at TEXT)'
@@ -76,7 +76,7 @@ async function cleanupUnknownMigrations(
   return applied;
 }
 
-async function clearDatabase(db: SqliteDatabase) {
+async function clearDatabase(db: SqliteDatabase): Promise<void> {
   logger.info('Clearing database');
 
   const tables: { name: string }[] = await db.all(
@@ -108,7 +108,7 @@ async function clearDatabase(db: SqliteDatabase) {
   }
 }
 
-async function migrateUp() {
+async function migrateUp(): Promise<void> {
   logger.info('Starting migration process (UP)');
 
   let db = await getDb();
@@ -160,7 +160,7 @@ async function migrateUp() {
   await db.close();
 }
 
-async function migrateDown() {
+async function migrateDown(): Promise<void> {
   logger.info('Starting migration rollback (DOWN)');
 
   const db = await getDb();
@@ -196,7 +196,7 @@ async function migrateDown() {
   await db.close();
 }
 
-async function checkMigrations() {
+async function checkMigrations(): Promise<boolean> {
   logger.info('Checking migration status');
 
   const db = await getDb();

--- a/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
+++ b/src/repositories/sqlite/SQLiteAccessKeyRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import {
@@ -55,7 +56,7 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
     await db.run('DELETE FROM access_keys WHERE expires_at <= ?', now);
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatAccessRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatAccessRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import {
@@ -84,7 +85,7 @@ export class SQLiteChatAccessRepository implements ChatAccessRepository {
     }));
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import {
@@ -27,7 +28,7 @@ export class SQLiteChatRepository implements ChatRepository {
     return row ? { chatId: row.chat_id, title: row.title } : undefined;
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteChatUserRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatUserRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import { type ChatUserRepository } from '../interfaces/ChatUserRepository.interface';
@@ -25,7 +26,7 @@ export class SQLiteChatUserRepository implements ChatUserRepository {
     return (rows ?? []).map((row) => row.user_id);
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteMessageRepository.ts
+++ b/src/repositories/sqlite/SQLiteMessageRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import type { ChatMessage } from '../../services/ai/AIService.interface';
 import type { StoredMessage } from '../../services/messages/StoredMessage.interface';
@@ -134,7 +135,7 @@ export class SQLiteMessageRepository implements MessageRepository {
     await db.run('DELETE FROM messages WHERE chat_id = ?', chatId);
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteSummaryRepository.ts
+++ b/src/repositories/sqlite/SQLiteSummaryRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import { type SummaryRepository } from '../interfaces/SummaryRepository.interface';
@@ -29,7 +30,7 @@ export class SQLiteSummaryRepository implements SummaryRepository {
     await db.run('DELETE FROM summaries WHERE chat_id = ?', chatId);
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/repositories/sqlite/SQLiteUserRepository.ts
+++ b/src/repositories/sqlite/SQLiteUserRepository.ts
@@ -1,4 +1,5 @@
 import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
 
 import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
 import {
@@ -59,7 +60,7 @@ export class SQLiteUserRepository implements UserRepository {
     );
   }
 
-  private async db() {
+  private async db(): Promise<Database> {
     return this.dbProvider.get();
   }
 }

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -23,7 +23,7 @@ export class ChatMemory {
     private limit: number
   ) {}
 
-  public async addMessage(message: StoredMessage) {
+  public async addMessage(message: StoredMessage): Promise<void> {
     logger.debug(
       { chatId: this.chatId, role: message.role, limit: this.limit },
       'Adding message'
@@ -69,7 +69,7 @@ export class ChatMemoryManager {
     return new ChatMemory(this.messages, this.summarizer, chatId, this.limit);
   }
 
-  public async reset(chatId: number) {
+  public async reset(chatId: number): Promise<void> {
     logger.debug({ chatId }, 'Resetting chat memory');
     await this.resetService.reset(chatId);
   }

--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -18,7 +18,7 @@ export class DefaultChatResetService implements ChatResetService {
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
   ) {}
 
-  async reset(chatId: number) {
+  async reset(chatId: number): Promise<void> {
     logger.debug({ chatId }, 'Resetting chat data');
     await this.messages.clearMessages(chatId);
     await this.summaries.clearSummary(chatId);

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -23,12 +23,12 @@ export class DefaultDialogueManager implements DialogueManager {
     this.timeoutMs = envService.getDialogueTimeoutMs();
   }
 
-  start(chatId: number) {
+  start(chatId: number): void {
     logger.debug({ chatId }, 'Starting dialogue');
     this.setTimer(chatId);
   }
 
-  extend(chatId: number) {
+  extend(chatId: number): void {
     logger.debug({ chatId }, 'Extending dialogue');
     this.setTimer(chatId);
   }
@@ -37,7 +37,7 @@ export class DefaultDialogueManager implements DialogueManager {
     return this.timers.has(chatId);
   }
 
-  private setTimer(chatId: number) {
+  private setTimer(chatId: number): void {
     const existing = this.timers.get(chatId);
     if (existing) {
       clearTimeout(existing);

--- a/src/services/env/EnvService.ts
+++ b/src/services/env/EnvService.ts
@@ -70,7 +70,7 @@ export class DefaultEnvService implements EnvService {
     this.env = envSchema.parse(process.env);
   }
 
-  getModels() {
+  getModels(): { ask: ChatModel; summary: ChatModel; interest: ChatModel } {
     return {
       ask: 'o3' as ChatModel,
       summary: 'o3-mini' as ChatModel,
@@ -78,7 +78,18 @@ export class DefaultEnvService implements EnvService {
     };
   }
 
-  getPromptFiles() {
+  getPromptFiles(): {
+    persona: string;
+    askSummary: string;
+    summarizationSystem: string;
+    previousSummary: string;
+    checkInterest: string;
+    userPrompt: string;
+    userPromptSystem: string;
+    priorityRulesSystem: string;
+    assessUsers: string;
+    replyTrigger: string;
+  } {
     return {
       persona: 'prompts/persona.md',
       askSummary: 'prompts/ask_summary_prompt.md',
@@ -124,7 +135,7 @@ export class TestEnvService implements EnvService {
     });
   }
 
-  getModels() {
+  getModels(): { ask: ChatModel; summary: ChatModel; interest: ChatModel } {
     return {
       ask: 'o3' as ChatModel,
       summary: 'o3-mini' as ChatModel,
@@ -132,7 +143,18 @@ export class TestEnvService implements EnvService {
     };
   }
 
-  getPromptFiles() {
+  getPromptFiles(): {
+    persona: string;
+    askSummary: string;
+    summarizationSystem: string;
+    previousSummary: string;
+    checkInterest: string;
+    userPrompt: string;
+    userPromptSystem: string;
+    priorityRulesSystem: string;
+    assessUsers: string;
+    replyTrigger: string;
+  } {
     return {
       persona: 'prompts/persona.md',
       askSummary: 'prompts/ask_summary_prompt.md',

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -16,6 +16,7 @@ import {
   USER_REPOSITORY_ID,
   type UserRepository,
 } from '../../repositories/interfaces/UserRepository.interface';
+import type { ChatMessage } from '../ai/AIService.interface';
 import { logger } from '../logging/logger';
 import { MessageService } from './MessageService.interface';
 import { StoredMessage } from './StoredMessage.interface';
@@ -29,7 +30,7 @@ export class RepositoryMessageService implements MessageService {
     @inject(CHAT_USER_REPOSITORY_ID) private chatUserRepo: ChatUserRepository
   ) {}
 
-  async addMessage(message: StoredMessage) {
+  async addMessage(message: StoredMessage): Promise<void> {
     logger.debug(
       { chatId: message.chatId, role: message.role },
       'Inserting message into database'
@@ -52,22 +53,22 @@ export class RepositoryMessageService implements MessageService {
     });
   }
 
-  async getMessages(chatId: number) {
+  async getMessages(chatId: number): Promise<ChatMessage[]> {
     logger.debug({ chatId }, 'Fetching messages from database');
     return this.messageRepo.findByChatId(chatId);
   }
 
-  async getCount(chatId: number) {
+  async getCount(chatId: number): Promise<number> {
     logger.debug({ chatId }, 'Counting messages in database');
     return this.messageRepo.countByChatId(chatId);
   }
 
-  async getLastMessages(chatId: number, limit: number) {
+  async getLastMessages(chatId: number, limit: number): Promise<ChatMessage[]> {
     logger.debug({ chatId, limit }, 'Fetching last messages from database');
     return this.messageRepo.findLastByChatId(chatId, limit);
   }
 
-  async clearMessages(chatId: number) {
+  async clearMessages(chatId: number): Promise<void> {
     logger.debug({ chatId }, 'Clearing messages table');
     await this.messageRepo.clearByChatId(chatId);
   }

--- a/src/services/summaries/RepositorySummaryService.ts
+++ b/src/services/summaries/RepositorySummaryService.ts
@@ -13,17 +13,17 @@ export class RepositorySummaryService implements SummaryService {
     @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository
   ) {}
 
-  async getSummary(chatId: number) {
+  async getSummary(chatId: number): Promise<string> {
     logger.debug({ chatId }, 'Fetching summary');
     return this.summaryRepo.findById(chatId);
   }
 
-  async setSummary(chatId: number, summary: string) {
+  async setSummary(chatId: number, summary: string): Promise<void> {
     logger.debug({ chatId }, 'Storing summary');
     await this.summaryRepo.upsert(chatId, summary);
   }
 
-  async clearSummary(chatId: number) {
+  async clearSummary(chatId: number): Promise<void> {
     logger.debug({ chatId }, 'Clearing summary');
     await this.summaryRepo.clearByChatId(chatId);
   }

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -16,7 +16,7 @@ class FakeHistorySummarizer implements HistorySummarizer {
 class FakeMessageService implements MessageService {
   private data = new Map<number, ChatMessage[]>();
 
-  async addMessage(message: StoredMessage) {
+  async addMessage(message: StoredMessage): Promise<void> {
     const list = this.data.get(message.chatId) ?? [];
     const entry: ChatMessage = {
       role: message.role,
@@ -34,16 +34,16 @@ class FakeMessageService implements MessageService {
     this.data.set(message.chatId, list);
   }
 
-  async getMessages(chatId: number) {
+  async getMessages(chatId: number): Promise<ChatMessage[]> {
     const list = this.data.get(chatId) ?? [];
     return list.map((m) => ({ ...m }));
   }
 
-  async getCount(chatId: number) {
+  async getCount(chatId: number): Promise<number> {
     return (this.data.get(chatId) ?? []).length;
   }
 
-  async getLastMessages(chatId: number, limit: number) {
+  async getLastMessages(chatId: number, limit: number): Promise<ChatMessage[]> {
     const list = this.data.get(chatId) ?? [];
     return list
       .slice(-limit)
@@ -51,7 +51,7 @@ class FakeMessageService implements MessageService {
       .map((m) => ({ ...m }));
   }
 
-  async clearMessages(chatId: number) {
+  async clearMessages(chatId: number): Promise<void> {
     this.data.set(chatId, []);
   }
 }

--- a/test/EnvService.test.ts
+++ b/test/EnvService.test.ts
@@ -4,7 +4,9 @@ import { TestEnvService } from '../src/services/env/EnvService';
 
 const OLD_ENV = { ...process.env };
 
-const setRequiredEnv = (overrides: Record<string, string | undefined> = {}) => {
+const setRequiredEnv = (
+  overrides: Record<string, string | undefined> = {}
+): void => {
   process.env.BOT_TOKEN = 'token';
   process.env.OPENAI_API_KEY = 'key';
   process.env.DATABASE_URL = 'file:///tmp/test.db';

--- a/test/InterestChecker.test.ts
+++ b/test/InterestChecker.test.ts
@@ -14,7 +14,12 @@ function createChecker(opts: {
   history?: ChatMessage[];
   summary?: string;
   aiResult?: { messageId: string; why: string } | null;
-}) {
+}): {
+  checker: DefaultInterestChecker;
+  messages: MessageService;
+  summaries: SummaryService;
+  ai: AIService;
+} {
   const messages: MessageService = {
     getCount: vi.fn().mockResolvedValue(opts.count),
     getLastMessages: vi.fn().mockResolvedValue(opts.history ?? []),

--- a/test/MigrationCleanup.test.ts
+++ b/test/MigrationCleanup.test.ts
@@ -7,14 +7,14 @@ class MockDb {
   migrations: string[] = [];
   hasMigrationsTable = false;
 
-  async get(query: string) {
+  async get(query: string): Promise<{ name: string } | undefined> {
     if (query.includes('sqlite_master') && query.includes('migrations')) {
       return this.hasMigrationsTable ? { name: 'migrations' } : undefined;
     }
     return undefined;
   }
 
-  async run(query: string, id?: string) {
+  async run(query: string, id?: string): Promise<void> {
     if (query.startsWith('CREATE TABLE')) {
       this.hasMigrationsTable = true;
     } else if (query.startsWith('INSERT INTO migrations')) {
@@ -26,15 +26,15 @@ class MockDb {
     }
   }
 
-  async all(query: string) {
+  async all(query: string): Promise<{ id: string }[]> {
     if (query === 'SELECT id FROM migrations') {
       return this.migrations.map((id) => ({ id }));
     }
     return [];
   }
 
-  async exec(_query: string) {}
-  async close() {}
+  async exec(_query: string): Promise<void> {}
+  async close(): Promise<void> {}
 }
 
 vi.mock('sqlite', () => ({
@@ -46,7 +46,7 @@ vi.mock('sqlite3', () => ({
 
 let mockDb: MockDb;
 
-async function loadMigrateModule() {
+async function loadMigrateModule(): Promise<void> {
   const mod = await import('../src/migrate');
   migrateUp = mod.migrateUp;
 }

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -11,7 +11,18 @@ class TempEnvService extends TestEnvService {
     super();
   }
 
-  override getPromptFiles() {
+  override getPromptFiles(): {
+    persona: string;
+    askSummary: string;
+    summarizationSystem: string;
+    previousSummary: string;
+    checkInterest: string;
+    userPrompt: string;
+    userPromptSystem: string;
+    priorityRulesSystem: string;
+    assessUsers: string;
+    replyTrigger: string;
+  } {
     return {
       persona: join(this.dir, 'persona.md'),
       askSummary: join(this.dir, 'ask_summary_prompt.md'),

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -11,7 +11,10 @@ import type { ChatMemoryManager } from '../src/services/chat/ChatMemory';
 import type { ChatResponder } from '../src/services/chat/ChatResponder';
 import type { TriggerPipeline } from '../src/services/chat/TriggerPipeline';
 import type { EnvService } from '../src/services/env/EnvService';
-import type { MessageContextExtractor } from '../src/services/messages/MessageContextExtractor';
+import type {
+  MessageContext,
+  MessageContextExtractor,
+} from '../src/services/messages/MessageContextExtractor';
 
 class MockEnvService {
   env = { BOT_TOKEN: 'token', ADMIN_CHAT_ID: 1 } as EnvService['env'];
@@ -36,8 +39,8 @@ class DummyAdmin {
 }
 
 class DummyExtractor {
-  extract() {
-    return {};
+  extract(): MessageContext {
+    return {} as MessageContext;
   }
 }
 

--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -14,7 +14,11 @@ const windows: WindowDefinition[] = [
   { id: 'second', text: 'Second window', buttons: [] },
 ];
 
-function setupRouter() {
+function setupRouter(): {
+  router: WindowRouter;
+  goHandler: (ctx: Context) => Promise<void> | void;
+  backHandler: (ctx: Context) => Promise<void> | void;
+} {
   const bot = new Telegraf<Context>('token');
   const actionSpy = vi.spyOn(bot, 'action');
   const router = new WindowRouter(


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/explicit-function-return-type` in ESLint
- add explicit return types throughout bot, repositories, services, and tests

## Testing
- `npm run lint`
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689e54ab33e88327a1e585ccac94cbc9