### PR TITLE
refactor: route admin chat management

### DIFF
--- a/src/bot/windowConfig.ts
+++ b/src/bot/windowConfig.ts
@@ -6,9 +6,17 @@ import {
   type RouteApi,
 } from '../infrastructure/telegramRouter';
 
-type WindowId = 'menu' | 'admin_menu' | 'chat_not_approved' | 'no_access';
+export type WindowId =
+  | 'menu'
+  | 'admin_menu'
+  | 'admin_chats'
+  | 'admin_chat'
+  | 'chat_not_approved'
+  | 'no_access'
+  | 'chat_approval_request'
+  | 'user_access_request';
 
-type WindowDefinition = RouteApi<WindowId>;
+export type WindowDefinition = RouteApi<WindowId>;
 
 const b = createButton<WindowId>;
 const r = createRoute<WindowId>;
@@ -16,9 +24,9 @@ const r = createRoute<WindowId>;
 interface WindowActions {
   exportData(ctx: Context): Promise<void> | void;
   resetMemory(ctx: Context): Promise<void> | void;
-  showAdminChatsMenu(ctx: Context): Promise<void> | void;
   requestChatAccess(ctx: Context): Promise<void> | void;
   requestUserAccess(ctx: Context): Promise<void> | void;
+  getChats(): Promise<{ id: number; title: string }[]>;
 }
 
 export function createWindows(actions: WindowActions): WindowDefinition[] {
@@ -51,10 +59,22 @@ export function createWindows(actions: WindowActions): WindowDefinition[] {
         b({
           text: '💬 Чаты',
           callback: 'admin_chats',
-          action: actions.showAdminChatsMenu,
+          target: 'admin_chats',
         }),
       ],
     }),
+    r({
+      id: 'admin_chats',
+      text: 'Выберите чат для управления:',
+      buttons: async () =>
+        (await actions.getChats()).map((chat) =>
+          b({
+            text: `${chat.title} (${chat.id})`,
+            callback: `admin_chat:${chat.id}`,
+          })
+        ),
+    }),
+    r({ id: 'admin_chat', text: '', buttons: [] }),
     r({
       id: 'chat_not_approved',
       text: 'Этот чат не находится в списке разрешённых.',
@@ -77,5 +97,7 @@ export function createWindows(actions: WindowActions): WindowDefinition[] {
         }),
       ],
     }),
+    r({ id: 'chat_approval_request', text: '', buttons: [] }),
+    r({ id: 'user_access_request', text: '', buttons: [] }),
   ];
 }

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -142,11 +142,9 @@ describe('TelegramBot', () => {
     );
     configureSpy.mockRestore();
 
-    const ctx = { reply: vi.fn() } as unknown as Context;
+    const ctx = { chat: { id: 1 }, reply: vi.fn() } as unknown as Context;
 
-    await (
-      bot as unknown as { showAdminChatsMenu: (ctx: Context) => Promise<void> }
-    ).showAdminChatsMenu(ctx);
+    await (bot as unknown as { router: any }).router.show(ctx, 'admin_chats');
 
     expect(approvalService.listAll).toHaveBeenCalled();
     expect(chatRepo.findById).toHaveBeenCalledWith(42);
@@ -165,7 +163,7 @@ describe('TelegramBot', () => {
     approvalService.getStatus.mockResolvedValue('approved');
     const actionSpy = vi.spyOn(Telegraf.prototype, 'action');
 
-    new TelegramBot(
+    const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,
       memories as unknown as ChatMemoryManager,
       new DummyAdmin() as unknown as AdminService,
@@ -186,19 +184,32 @@ describe('TelegramBot', () => {
     }
     const handler = call[1];
 
+    // simulate entering admin_chats route to populate history
+    await (
+      bot as unknown as { router: unknown } as { router: any }
+    ).router.show(
+      { chat: { id: 1 }, reply: vi.fn() } as unknown as Context,
+      'admin_chats'
+    );
+
     const ctx = {
       chat: { id: 1 },
       match: ['admin_chat:42', '42'],
       answerCbQuery: vi.fn(),
+      deleteMessage: vi.fn(async () => {}),
       reply: vi.fn(),
     } as unknown as Context;
 
     await handler(ctx);
 
     expect(approvalService.getStatus).toHaveBeenCalledWith(42);
+    expect(ctx.deleteMessage).toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith('Статус чата 42: approved', {
       reply_markup: {
-        inline_keyboard: [[{ text: 'Забанить', callback_data: 'chat_ban:42' }]],
+        inline_keyboard: [
+          [{ text: 'Забанить', callback_data: 'chat_ban:42' }],
+          [{ text: '⬅️ Назад', callback_data: 'back' }],
+        ],
       },
     });
   });
@@ -206,9 +217,12 @@ describe('TelegramBot', () => {
   it('chat_ban updates message', async () => {
     const memories = new MockChatMemoryManager();
     const approvalService = new DummyApprovalService();
+    approvalService.getStatus
+      .mockResolvedValueOnce('approved')
+      .mockResolvedValueOnce('banned');
     const actionSpy = vi.spyOn(Telegraf.prototype, 'action');
 
-    new TelegramBot(
+    const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,
       memories as unknown as ChatMemoryManager,
       new DummyAdmin() as unknown as AdminService,
@@ -229,21 +243,39 @@ describe('TelegramBot', () => {
     }
     const handler = call[1];
 
+    // navigate to admin_chat view for chat 7
+    await (bot as unknown as { router: any }).router.show(
+      { chat: { id: 1 }, reply: vi.fn() } as unknown as Context,
+      'admin_chats'
+    );
+    await (
+      bot as unknown as {
+        showAdminChat: (ctx: Context, id: number) => Promise<void>;
+      }
+    ).showAdminChat(
+      { chat: { id: 1 }, reply: vi.fn() } as unknown as Context,
+      7
+    );
+
     const ctx = {
       chat: { id: 1 },
       match: ['chat_ban:7', '7'],
       telegram: { sendMessage: vi.fn() },
       answerCbQuery: vi.fn(),
-      editMessageText: vi.fn(),
+      deleteMessage: vi.fn(async () => {}),
+      reply: vi.fn(),
     } as unknown as Context;
 
     await handler(ctx);
 
     expect(approvalService.ban).toHaveBeenCalledWith(7);
-    expect(ctx.editMessageText).toHaveBeenCalledWith('Чат 7 забанен', {
+    expect(ctx.telegram.sendMessage).toHaveBeenCalledWith(7, 'Доступ запрещён');
+    expect(ctx.deleteMessage).toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith('Статус чата 7: banned', {
       reply_markup: {
         inline_keyboard: [
           [{ text: 'Разбанить', callback_data: 'chat_unban:7' }],
+          [{ text: '⬅️ Назад', callback_data: 'back' }],
         ],
       },
     });
@@ -315,7 +347,10 @@ describe('TelegramBot', () => {
     );
     configureSpy.mockRestore();
 
-    const telegram = { sendMessage: vi.fn() };
+    const sendMessageSpy = vi
+      .spyOn((bot as unknown as { bot: Telegraf }).bot.telegram, 'sendMessage')
+      .mockResolvedValue(undefined as never);
+
     const ctx = {
       chat: { id: 5 },
       from: {
@@ -325,14 +360,13 @@ describe('TelegramBot', () => {
         username: 'jdoe',
       },
       reply: vi.fn(),
-      telegram,
     } as unknown as Context;
 
     await (
       bot as unknown as { handleRequestAccess: (ctx: Context) => Promise<void> }
     ).handleRequestAccess(ctx);
 
-    expect(telegram.sendMessage).toHaveBeenCalledWith(
+    expect(sendMessageSpy).toHaveBeenCalledWith(
       1,
       'Chat 5 user 6 (John Doe @jdoe) requests data access.',
       expect.objectContaining({ reply_markup: expect.any(Object) })

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -144,7 +144,10 @@ describe('TelegramBot', () => {
 
     const ctx = { chat: { id: 1 }, reply: vi.fn() } as unknown as Context;
 
-    await (bot as unknown as { router: any }).router.show(ctx, 'admin_chats');
+    await (bot as unknown as { router: any }).router.show(ctx, 'admin_chats', {
+      loadData: () =>
+        (bot as unknown as { getChats: () => Promise<unknown> }).getChats(),
+    });
 
     expect(approvalService.listAll).toHaveBeenCalled();
     expect(chatRepo.findById).toHaveBeenCalledWith(42);
@@ -189,7 +192,8 @@ describe('TelegramBot', () => {
       bot as unknown as { router: unknown } as { router: any }
     ).router.show(
       { chat: { id: 1 }, reply: vi.fn() } as unknown as Context,
-      'admin_chats'
+      'admin_chats',
+      { loadData: () => [] }
     );
 
     const ctx = {
@@ -246,7 +250,8 @@ describe('TelegramBot', () => {
     // navigate to admin_chat view for chat 7
     await (bot as unknown as { router: any }).router.show(
       { chat: { id: 1 }, reply: vi.fn() } as unknown as Context,
-      'admin_chats'
+      'admin_chats',
+      { loadData: () => [] }
     );
     await (
       bot as unknown as {
@@ -633,7 +638,9 @@ describe('TelegramBot', () => {
     botWithRouter.router = { show: vi.fn() };
     const ctx = { chat: { id: 1 } } as unknown as Context;
     await botWithRouter.showMenu(ctx);
-    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'admin_menu');
+    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'admin_menu', {
+      resetStack: true,
+    });
   });
 
   it('shows banned and pending states in menu', async () => {
@@ -671,7 +678,8 @@ describe('TelegramBot', () => {
     await botWithRouter.showMenu(pendingCtx);
     expect(botWithRouter.router.show).toHaveBeenLastCalledWith(
       pendingCtx,
-      'chat_not_approved'
+      'chat_not_approved',
+      { resetStack: true }
     );
   });
 
@@ -704,7 +712,9 @@ describe('TelegramBot', () => {
     botWithRouter.router = { show: vi.fn() };
     const ctx = { chat: { id: 2 }, from: { id: 5 } } as unknown as Context;
     await botWithRouter.showMenu(ctx);
-    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'no_access');
+    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'no_access', {
+      resetStack: true,
+    });
   });
 
   it('handles pending and banned chats in text handler', async () => {

--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -24,13 +24,17 @@ const windows: RouteApi<RouteId>[] = [
 ];
 
 function setupRouter(): {
-  router: ReturnType<typeof registerRoutes<RouteId>>;
+  router: ReturnType<typeof registerRoutes<RouteId, Record<string, never>>>;
   goHandler: (ctx: Context) => Promise<void> | void;
   backHandler: (ctx: Context) => Promise<void> | void;
 } {
   const bot = new Telegraf<Context>('token');
   const actionSpy = vi.spyOn(bot, 'action');
-  const router = registerRoutes<RouteId>(bot, windows);
+  const router = registerRoutes<RouteId, Record<string, never>>(
+    bot,
+    windows,
+    {}
+  );
   const goCall = actionSpy.mock.calls.find(
     ([pattern]) => pattern === 'to_second'
   );


### PR DESCRIPTION
## Summary
- build admin chat list route from dynamic repository data
- support asynchronous button generation in telegram router
- update tests for router-based admin chat navigation

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689f67dde35c83278ecc4057b5be247a