### PR TITLE
Raise coverage thresholds and test logger service

### DIFF
--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('logger', () => {
+  const OLD_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...OLD_ENV };
+    vi.resetModules();
+  });
+
+  it('creates logger in test env', async () => {
+    process.env.NODE_ENV = 'test';
+    vi.resetModules();
+    const { logger } = await import('../src/services/logging/logger');
+    expect(logger).toBeDefined();
+  });
+
+  it('creates logger in non-test env', async () => {
+    process.env = {
+      ...OLD_ENV,
+      NODE_ENV: 'production',
+      BOT_TOKEN: 'token',
+      OPENAI_API_KEY: 'key',
+      DATABASE_URL: 'file:///tmp/test.db',
+      ADMIN_CHAT_ID: '1',
+      INTEREST_MESSAGE_INTERVAL: '1',
+      CHAT_HISTORY_LIMIT: '2',
+    };
+    vi.resetModules();
+    const { logger } = await import('../src/services/logging/logger');
+    expect(logger).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: 'v8',
-      thresholds: { lines: 86.55, functions: 84.21, branches: 84.52 },
+      thresholds: { lines: 90, functions: 90, branches: 90 },
       include: ['src/**/*.ts'],
       exclude: [
         'dist/**',
@@ -14,7 +14,6 @@ export default defineConfig({
         'src/container.ts',
         'src/repositories/**',
         'src/services/env/**',
-        'src/services/logging/**',
         '**/*.interface.ts',
       ],
     },


### PR DESCRIPTION
## Summary
- enforce 90% coverage on lines, functions, and branches
- include logging service in coverage metrics
- add tests for logger to exercise both test and production environments

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689f863949c88327a4ff3eb66e6562fd