### PR TITLE
test: add integration setup with mocks

### DIFF
--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Ensure we are in test mode before loading the container
+process.env.NODE_ENV = 'test';
+const tmpDbDir = mkdtempSync(join(tmpdir(), 'ark-bot-test-'));
+process.env.DATABASE_URL = `file://${join(tmpDbDir, 'test.db')}`;
+
+import { container } from '../../src/container';
+import { migrateUp } from '../../src/migrate';
+import {
+  type AIService,
+  AI_SERVICE_ID,
+  type ChatMessage,
+} from '../../src/services/ai/AIService.interface';
+import type { TriggerReason } from '../../src/triggers/Trigger.interface';
+import type { Context, Telegram } from 'telegraf';
+
+// Stable mock for AIService
+class MockAIService implements AIService {
+  async ask(
+    _history: ChatMessage[],
+    _summary?: string,
+    _triggerReason?: TriggerReason
+  ): Promise<string> {
+    return 'mocked answer';
+  }
+
+  async summarize(_history: ChatMessage[], _prev?: string): Promise<string> {
+    return 'mocked summary';
+  }
+
+  async checkInterest(
+    _history: ChatMessage[],
+    _summary: string
+  ): Promise<{ messageId: string; why: string } | null> {
+    return null;
+  }
+
+  async assessUsers(
+    _messages: ChatMessage[],
+    _prevAttitudes?: { username: string; attitude: string }[]
+  ): Promise<{ username: string; attitude: string }[]> {
+    return [];
+  }
+}
+
+// Stable mock for Telegram API
+class MockTelegram implements Partial<Telegram> {
+  public sendMessage = async () => ({ message_id: 0 });
+  public sendChatAction = async () => {};
+  public sendDocument = async () => ({ message_id: 0 });
+  public deleteWebhook = async () => {};
+  public editMessageText = async () => {};
+}
+
+export async function init(): Promise<void> {
+  // Run database migrations for the temporary database
+  await migrateUp();
+  // Replace AI service with mock implementation
+  container
+    .rebind<AIService>(AI_SERVICE_ID)
+    .to(MockAIService)
+    .inSingletonScope();
+}
+
+export interface MockContextOptions {
+  chatId?: number;
+  userId?: number;
+  text?: string;
+}
+
+// Helper to create a Telegram context for tests
+export function createContext(options: MockContextOptions = {}): Context {
+  const { chatId = 1, userId = 1, text = '' } = options;
+  const telegram = new MockTelegram();
+  return {
+    chat: { id: chatId, type: 'private' } as any,
+    from: {
+      id: userId,
+      is_bot: false,
+      first_name: 'user',
+      username: 'user',
+    } as any,
+    message: {
+      message_id: 1,
+      date: Math.floor(Date.now() / 1000),
+      chat: { id: chatId, type: 'private' },
+      from: { id: userId, is_bot: false, first_name: 'user', username: 'user' },
+      text,
+    } as any,
+    telegram: telegram as unknown as Telegram,
+    reply: async () => {},
+    replyWithDocument: async () => ({ message_id: 0 }),
+    answerCbQuery: async () => {},
+    sendChatAction: async () => {},
+  } as unknown as Context;
+}
+
+export { container };
+export { MockAIService, MockTelegram };


### PR DESCRIPTION
## Summary
- add integration test setup with temporary SQLite DB
- mock AI service and Telegram API for integration tests
- helper to create Telegram context for tests

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689f87e337d48327823983e56d575fb8