### PR TITLE
Refactor telegram router to tree navigation

### DIFF
--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -175,6 +175,22 @@ describe('telegramRouter', () => {
     expect(ctx.reply).not.toHaveBeenCalled();
   });
 
+  it('reuses existing nodes and updates load data', async () => {
+    const { router } = await setupRouter();
+    const ctx = { chat: { id: 1 }, reply: vi.fn() } as unknown as Context;
+
+    await router.show(ctx, 'first');
+    await router.show(ctx, 'second');
+    await router.show(ctx, 'first');
+    await router.show(ctx, 'second');
+    await router.show(ctx, 'first', { loadData: async () => undefined });
+    await router.show(ctx, 'second', { loadData: async () => undefined });
+    await router.show(ctx, 'second');
+    await router.show(ctx, 'second', { loadData: async () => undefined });
+
+    expect(ctx.reply).toHaveBeenCalledTimes(8);
+  });
+
   it('throws when context has no chat', async () => {
     const { router } = await setupRouter();
     await expect(


### PR DESCRIPTION
## Summary
- refactor telegram router to use node trees instead of history stacks
- update navigation logic and add tests for node reuse and data updates

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a055fabd348327bdacf65cb5d7e8f7