### PR TITLE
feat: lazily create telegram routes

### DIFF
--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -210,4 +210,41 @@ describe('telegramRouter', () => {
 
     expect(() => registerRoutes<RouteId>(bot, [needsDataRoute])).not.toThrow();
   });
+
+  it('registers buttons lazily for routes requiring data', async () => {
+    const bot = new Telegraf<Context>('token');
+    const actionSpy = vi.spyOn(bot, 'action');
+    const needsDataRoute = r('needs_data', async ({ loadData }) => {
+      const items = (await loadData()) as string[];
+      return {
+        text: 'needs data',
+        buttons: items.map((text) => b({ text, callback: text })),
+      };
+    });
+    const router = registerRoutes<RouteId>(bot, [needsDataRoute]);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(actionSpy).toHaveBeenCalledTimes(1);
+    expect(actionSpy.mock.calls[0][0]).toBe('back');
+
+    const ctx = { chat: { id: 1 }, reply: vi.fn() } as unknown as Context;
+    await router.show(ctx, 'needs_data', { loadData: async () => ['x'] });
+
+    const call = actionSpy.mock.calls.find(([pattern]) => pattern === 'x');
+    expect(call).toBeTruthy();
+  });
+
+  it('does nothing when data for route is missing', async () => {
+    const bot = new Telegraf<Context>('token');
+    const needsDataRoute = r('needs_data', async ({ loadData }) => {
+      const items = (await loadData()) as string[];
+      return {
+        text: 'needs data',
+        buttons: items.map((text) => b({ text, callback: text })),
+      };
+    });
+    const router = registerRoutes<RouteId>(bot, [needsDataRoute]);
+    const ctx = { chat: { id: 1 }, reply: vi.fn() } as unknown as Context;
+    await router.show(ctx, 'needs_data');
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- lazily build and register telegram routes only after successful `route.build`
- await optional async data loaders
- skip registering actions for data-driven routes until they are shown
- add tests for lazy route registration and missing data handling

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a05af2e0788327b731d0194a5966ca