### PR TITLE
feat: track route parents in router

### DIFF
--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -113,7 +113,7 @@ describe('TelegramBot', () => {
     );
   });
 
-  it('shows admin chats menu with back button', async () => {
+  it('shows admin chats menu', async () => {
     const memories = new MockChatMemoryManager();
     const configureSpy = vi
       .spyOn(
@@ -174,7 +174,6 @@ describe('TelegramBot', () => {
       reply_markup: {
         inline_keyboard: [
           [{ text: 'Test Chat (42)', callback_data: 'admin_chat:42' }],
-          [{ text: '⬅️ Назад', callback_data: 'back' }],
         ],
       },
     });
@@ -230,15 +229,12 @@ describe('TelegramBot', () => {
     expect(ctx.deleteMessage).toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith('Статус чата 42: approved', {
       reply_markup: {
-        inline_keyboard: [
-          [{ text: 'Забанить', callback_data: 'chat_ban:42' }],
-          [{ text: '⬅️ Назад', callback_data: 'back' }],
-        ],
+        inline_keyboard: [[{ text: 'Забанить', callback_data: 'chat_ban:42' }]],
       },
     });
   });
 
-  it('returns to admin_chats with list after back from admin_chat', async () => {
+  it('does nothing on back from admin_chat without parent', async () => {
     const memories = new MockChatMemoryManager();
     const approvalService = new DummyApprovalService();
     approvalService.getStatus.mockResolvedValue('approved');
@@ -289,16 +285,8 @@ describe('TelegramBot', () => {
 
     await backHandler(ctxBack);
 
-    expect(loadChats).toHaveBeenCalledTimes(2);
-    expect(ctxBack.reply).toHaveBeenCalledWith('Выберите чат для управления:', {
-      reply_markup: {
-        inline_keyboard: [
-          [{ text: 'Chat A (42)', callback_data: 'admin_chat:42' }],
-          [{ text: 'Chat B (43)', callback_data: 'admin_chat:43' }],
-          [{ text: '⬅️ Назад', callback_data: 'back' }],
-        ],
-      },
-    });
+    expect(loadChats).toHaveBeenCalledTimes(1);
+    expect(ctxBack.reply).not.toHaveBeenCalled();
   });
 
   it('chat_ban updates message', async () => {
@@ -363,7 +351,6 @@ describe('TelegramBot', () => {
       reply_markup: {
         inline_keyboard: [
           [{ text: 'Разбанить', callback_data: 'chat_unban:7' }],
-          [{ text: '⬅️ Назад', callback_data: 'back' }],
         ],
       },
     });

--- a/test/bot/WindowRouter.test.ts
+++ b/test/bot/WindowRouter.test.ts
@@ -328,10 +328,7 @@ describe('telegramRouter', () => {
     await promise;
     expect(ctx.reply).toHaveBeenNthCalledWith(2, 'needs data', {
       reply_markup: {
-        inline_keyboard: [
-          [{ text: 'delayed', callback_data: 'delayed' }],
-          [{ text: '⬅️ Назад', callback_data: 'back' }],
-        ],
+        inline_keyboard: [[{ text: 'delayed', callback_data: 'delayed' }]],
       },
     });
     expect((router as any).current.get(1)?.id).toBe('needs_data');


### PR DESCRIPTION
## Summary
- map route parents and clear navigation history when opening root routes
- only show back button for routes with a parent
- adjust tests for new navigation behavior

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a0620b457083278943411078f4fed0