### PR TITLE
feat: add local message store to chat memory

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -60,6 +60,10 @@ import {
   DefaultInterestChecker,
   INTEREST_CHECKER_ID,
 } from './services/interest/InterestChecker';
+import {
+  LOCAL_MESSAGE_STORE_ID,
+  LocalMessageStoreImpl,
+} from './services/messages/LocalMessageStore';
 import type { MessageContextExtractor } from './services/messages/MessageContextExtractor';
 import {
   DefaultMessageContextExtractor,
@@ -89,6 +93,10 @@ container.bind(AI_SERVICE_ID).to(ChatGPTService).inSingletonScope();
 container
   .bind(MESSAGE_SERVICE_ID)
   .to(RepositoryMessageService)
+  .inSingletonScope();
+container
+  .bind(LOCAL_MESSAGE_STORE_ID)
+  .to(LocalMessageStoreImpl)
   .inSingletonScope();
 container
   .bind(SUMMARY_SERVICE_ID)


### PR DESCRIPTION
## Summary
- store messages in LocalMessageStore when ChatMemory records history
- inject and bind LocalMessageStore for ChatMemoryManager
- reset LocalMessageStore alongside persistent history

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a2f28c14d8832795b694dc4db024ed