### PR TITLE
Rename LocalMessageStore to InterestMessageStore

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -61,9 +61,9 @@ import {
   INTEREST_CHECKER_ID,
 } from './services/interest/InterestChecker';
 import {
-  LOCAL_MESSAGE_STORE_ID,
-  LocalMessageStoreImpl,
-} from './services/messages/LocalMessageStore';
+  INTEREST_MESSAGE_STORE_ID,
+  InterestMessageStoreImpl,
+} from './services/messages/InterestMessageStore';
 import type { MessageContextExtractor } from './services/messages/MessageContextExtractor';
 import {
   DefaultMessageContextExtractor,
@@ -95,8 +95,8 @@ container
   .to(RepositoryMessageService)
   .inSingletonScope();
 container
-  .bind(LOCAL_MESSAGE_STORE_ID)
-  .to(LocalMessageStoreImpl)
+  .bind(INTEREST_MESSAGE_STORE_ID)
+  .to(InterestMessageStoreImpl)
   .inSingletonScope();
 container
   .bind(SUMMARY_SERVICE_ID)

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -4,9 +4,9 @@ import { ChatMessage } from '../ai/AIService.interface';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
 import { logger } from '../logging/logger';
 import {
-  LOCAL_MESSAGE_STORE_ID,
-  type LocalMessageStore,
-} from '../messages/LocalMessageStore';
+  INTEREST_MESSAGE_STORE_ID,
+  type InterestMessageStore,
+} from '../messages/InterestMessageStore';
 import {
   MESSAGE_SERVICE_ID,
   type MessageService,
@@ -23,7 +23,7 @@ export class ChatMemory {
   constructor(
     private messages: MessageService,
     private summarizer: HistorySummarizer,
-    private localStore: LocalMessageStore,
+    private localStore: InterestMessageStore,
     private chatId: number,
     private limit: number
   ) {}
@@ -65,7 +65,7 @@ export class ChatMemoryManager {
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(HISTORY_SUMMARIZER_ID) private summarizer: HistorySummarizer,
     @inject(CHAT_RESET_SERVICE_ID) private resetService: ChatResetService,
-    @inject(LOCAL_MESSAGE_STORE_ID) private localStore: LocalMessageStore,
+    @inject(INTEREST_MESSAGE_STORE_ID) private localStore: InterestMessageStore,
     @inject(ENV_SERVICE_ID) envService: EnvService
   ) {
     this.limit = envService.env.CHAT_HISTORY_LIMIT;

--- a/src/services/messages/InterestMessageStore.ts
+++ b/src/services/messages/InterestMessageStore.ts
@@ -1,10 +1,9 @@
-/* eslint-disable import/no-unused-modules */
 import type { ServiceIdentifier } from 'inversify';
 
 import type { ChatMessage } from '../ai/AIService.interface';
 import type { StoredMessage } from './StoredMessage.interface';
 
-export interface LocalMessageStore {
+export interface InterestMessageStore {
   addMessage(msg: StoredMessage): void;
   getMessages(chatId: number): ChatMessage[];
   getCount(chatId: number): number;
@@ -12,11 +11,11 @@ export interface LocalMessageStore {
   clearMessages(chatId: number): void;
 }
 
-export const LOCAL_MESSAGE_STORE_ID = Symbol.for(
-  'LocalMessageStore'
-) as ServiceIdentifier<LocalMessageStore>;
+export const INTEREST_MESSAGE_STORE_ID = Symbol.for(
+  'InterestMessageStore'
+) as ServiceIdentifier<InterestMessageStore>;
 
-export class LocalMessageStoreImpl implements LocalMessageStore {
+export class InterestMessageStoreImpl implements InterestMessageStore {
   private readonly messages = new Map<number, StoredMessage[]>();
 
   addMessage(msg: StoredMessage): void {

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -6,7 +6,7 @@ import { ChatResetService } from '../src/services/chat/ChatResetService.interfac
 import { HistorySummarizer } from '../src/services/chat/HistorySummarizer';
 import { EnvService } from '../src/services/env/EnvService';
 import { MessageService } from '../src/services/messages/MessageService.interface';
-import { LocalMessageStore } from '../src/services/messages/LocalMessageStore';
+import { InterestMessageStore } from '../src/services/messages/InterestMessageStore';
 import { StoredMessage } from '../src/services/messages/StoredMessage.interface';
 
 class FakeHistorySummarizer implements HistorySummarizer {
@@ -57,7 +57,7 @@ class FakeMessageService implements MessageService {
   }
 }
 
-class FakeLocalMessageStore implements LocalMessageStore {
+class FakeInterestMessageStore implements InterestMessageStore {
   addMessage = vi.fn();
   getMessages = vi.fn(() => []);
   getCount = vi.fn(() => 0);
@@ -68,13 +68,13 @@ class FakeLocalMessageStore implements LocalMessageStore {
 describe('ChatMemory', () => {
   let summarizer: FakeHistorySummarizer;
   let messages: FakeMessageService;
-  let localStore: FakeLocalMessageStore;
+  let localStore: FakeInterestMessageStore;
   let memory: ChatMemory;
 
   beforeEach(() => {
     summarizer = new FakeHistorySummarizer();
     messages = new FakeMessageService();
-    localStore = new FakeLocalMessageStore();
+    localStore = new FakeInterestMessageStore();
     memory = new ChatMemory(messages, summarizer, localStore, 1, 2);
   });
 
@@ -153,7 +153,7 @@ describe('ChatMemory', () => {
     ]);
   });
 
-  it('stores messages in LocalMessageStore', async () => {
+  it('stores messages in InterestMessageStore', async () => {
     const msg: StoredMessage = { chatId: 1, role: 'user', content: 'hi' };
     await memory.addMessage(msg);
     expect(localStore.addMessage).toHaveBeenCalledWith({ ...msg, chatId: 1 });
@@ -167,7 +167,7 @@ describe('ChatMemoryManager', () => {
   class DummyEnvService implements EnvService {
     env = { CHAT_HISTORY_LIMIT: 2 } as EnvService['env'];
   }
-  class DummyLocalMessageStore implements LocalMessageStore {
+  class DummyInterestMessageStore implements InterestMessageStore {
     addMessage = vi.fn();
     getMessages = vi.fn(() => []);
     getCount = vi.fn(() => 0);
@@ -180,7 +180,7 @@ describe('ChatMemoryManager', () => {
       new FakeMessageService(),
       new FakeHistorySummarizer(),
       new DummyResetService(),
-      new DummyLocalMessageStore(),
+      new DummyInterestMessageStore(),
       new DummyEnvService()
     );
     const mem = manager.get(5);
@@ -189,7 +189,7 @@ describe('ChatMemoryManager', () => {
 
   it('resets memory using ChatResetService', async () => {
     const reset = new DummyResetService();
-    const local = new DummyLocalMessageStore();
+    const local = new DummyInterestMessageStore();
     const manager = new ChatMemoryManager(
       new FakeMessageService(),
       new FakeHistorySummarizer(),


### PR DESCRIPTION
## Summary
- replace LocalMessageStore with InterestMessageStore and new INTEREST_MESSAGE_STORE_ID
- wire new store into chat memory and container bindings
- update unit tests for renamed store

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a2f51434448327acc4f073ddd35d9e