### PR TITLE
refactor: remove interest interval constraints

### DIFF
--- a/src/services/env/EnvService.ts
+++ b/src/services/env/EnvService.ts
@@ -5,36 +5,17 @@ import { injectable } from 'inversify';
 import { ChatModel } from 'openai/resources/shared';
 import { z } from 'zod';
 
-const envSchema = z
-  .object({
-    BOT_TOKEN: z.string().min(1),
-    OPENAI_API_KEY: z.string().min(1),
-    DATABASE_URL: z.string().min(1),
-    CHAT_HISTORY_LIMIT: z.coerce.number().int().positive().default(50),
-    LOG_LEVEL: z.string().default('debug'),
-    ADMIN_CHAT_ID: z.coerce.number(),
-    NODE_ENV: z.string().default('development'),
-    LOG_PROMPTS: z.coerce.boolean().default(false),
-    INTEREST_MESSAGE_INTERVAL: z.coerce.number().int().positive(),
-  })
-  .superRefine((env, ctx) => {
-    if (env.INTEREST_MESSAGE_INTERVAL >= env.CHAT_HISTORY_LIMIT) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'INTEREST_MESSAGE_INTERVAL must be less than CHAT_HISTORY_LIMIT',
-        path: ['INTEREST_MESSAGE_INTERVAL'],
-      });
-    }
-    if (env.CHAT_HISTORY_LIMIT % env.INTEREST_MESSAGE_INTERVAL !== 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'CHAT_HISTORY_LIMIT must be divisible by INTEREST_MESSAGE_INTERVAL',
-        path: ['INTEREST_MESSAGE_INTERVAL'],
-      });
-    }
-  });
+const envSchema = z.object({
+  BOT_TOKEN: z.string().min(1),
+  OPENAI_API_KEY: z.string().min(1),
+  DATABASE_URL: z.string().min(1),
+  CHAT_HISTORY_LIMIT: z.coerce.number().int().positive().default(50),
+  LOG_LEVEL: z.string().default('debug'),
+  ADMIN_CHAT_ID: z.coerce.number(),
+  NODE_ENV: z.string().default('development'),
+  LOG_PROMPTS: z.coerce.boolean().default(false),
+  INTEREST_MESSAGE_INTERVAL: z.coerce.number().int().positive(),
+});
 
 export type Env = z.infer<typeof envSchema>;
 

--- a/test/EnvService.test.ts
+++ b/test/EnvService.test.ts
@@ -45,28 +45,6 @@ describe('EnvService', () => {
     expect(env.env.LOG_LEVEL).toBe('silent');
   });
 
-  it('throws when INTEREST_MESSAGE_INTERVAL >= CHAT_HISTORY_LIMIT', () => {
-    setRequiredEnv({
-      CHAT_HISTORY_LIMIT: '50',
-      INTEREST_MESSAGE_INTERVAL: '50',
-    });
-
-    expect(() => new TestEnvService()).toThrow(
-      'INTEREST_MESSAGE_INTERVAL must be less than CHAT_HISTORY_LIMIT'
-    );
-  });
-
-  it('throws when CHAT_HISTORY_LIMIT is not divisible by INTEREST_MESSAGE_INTERVAL', () => {
-    setRequiredEnv({
-      CHAT_HISTORY_LIMIT: '50',
-      INTEREST_MESSAGE_INTERVAL: '30',
-    });
-
-    expect(() => new TestEnvService()).toThrow(
-      'CHAT_HISTORY_LIMIT must be divisible by INTEREST_MESSAGE_INTERVAL'
-    );
-  });
-
   it('getModels returns correct models', () => {
     setRequiredEnv();
     const env = new TestEnvService();

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -24,7 +24,6 @@ describe('logger', () => {
       DATABASE_URL: 'file:///tmp/test.db',
       ADMIN_CHAT_ID: '1',
       INTEREST_MESSAGE_INTERVAL: '1',
-      CHAT_HISTORY_LIMIT: '2',
     };
     vi.resetModules();
     const { logger } = await import('../src/services/logging/logger');


### PR DESCRIPTION
## Summary
- drop INTEREST_MESSAGE_INTERVAL vs CHAT_HISTORY_LIMIT validations
- remove related EnvService tests
- simplify Logger test environment setup

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a2f8e1906c832791098b93cdaf3dcb