### PR TITLE
Add chat configs table migration

### DIFF
--- a/migrations/012_create_chat_configs_table.down.sql
+++ b/migrations/012_create_chat_configs_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS chat_configs;

--- a/migrations/012_create_chat_configs_table.up.sql
+++ b/migrations/012_create_chat_configs_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS chat_configs (
+  chat_id INTEGER PRIMARY KEY,
+  history_limit INTEGER NOT NULL DEFAULT 50,
+  interest_interval INTEGER NOT NULL DEFAULT 25
+);


### PR DESCRIPTION
## Summary
- add SQL migration creating `chat_configs` table for per-chat settings

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `BOT_TOKEN=1 OPENAI_API_KEY=1 DATABASE_URL=file:memory.db ADMIN_CHAT_ID=1 INTEREST_MESSAGE_INTERVAL=25 npm run migration:up`


------
https://chatgpt.com/codex/tasks/task_e_68a30e3275d4832788e7bad1fc90f7dc