### PR TITLE
feat: add chat config service

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -9,6 +9,7 @@ import {
 } from './repositories/DbProvider';
 import { ACCESS_KEY_REPOSITORY_ID } from './repositories/interfaces/AccessKeyRepository.interface';
 import { CHAT_ACCESS_REPOSITORY_ID } from './repositories/interfaces/ChatAccessRepository.interface';
+import { CHAT_CONFIG_REPOSITORY_ID } from './repositories/interfaces/ChatConfigRepository.interface';
 import { CHAT_REPOSITORY_ID } from './repositories/interfaces/ChatRepository.interface';
 import { CHAT_USER_REPOSITORY_ID } from './repositories/interfaces/ChatUserRepository.interface';
 import { MESSAGE_REPOSITORY_ID } from './repositories/interfaces/MessageRepository.interface';
@@ -16,6 +17,7 @@ import { SUMMARY_REPOSITORY_ID } from './repositories/interfaces/SummaryReposito
 import { USER_REPOSITORY_ID } from './repositories/interfaces/UserRepository.interface';
 import { SQLiteAccessKeyRepository } from './repositories/sqlite/SQLiteAccessKeyRepository';
 import { SQLiteChatAccessRepository } from './repositories/sqlite/SQLiteChatAccessRepository';
+import { SQLiteChatConfigRepository } from './repositories/sqlite/SQLiteChatConfigRepository';
 import { SQLiteChatRepository } from './repositories/sqlite/SQLiteChatRepository';
 import { SQLiteChatUserRepository } from './repositories/sqlite/SQLiteChatUserRepository';
 import { SQLiteMessageRepository } from './repositories/sqlite/SQLiteMessageRepository';
@@ -29,6 +31,11 @@ import {
   CHAT_APPROVAL_SERVICE_ID,
   DefaultChatApprovalService,
 } from './services/chat/ChatApprovalService';
+import {
+  CHAT_CONFIG_SERVICE_ID,
+  type ChatConfigService,
+  RepositoryChatConfigService,
+} from './services/chat/ChatConfigService';
 import { ChatMemoryManager } from './services/chat/ChatMemory';
 import { CHAT_RESET_SERVICE_ID } from './services/chat/ChatResetService.interface';
 import type { ChatResponder } from './services/chat/ChatResponder';
@@ -116,6 +123,11 @@ container
   .inSingletonScope();
 
 container
+  .bind<ChatConfigService>(CHAT_CONFIG_SERVICE_ID)
+  .to(RepositoryChatConfigService)
+  .inSingletonScope();
+
+container
   .bind(INTEREST_CHECKER_ID)
   .to(DefaultInterestChecker)
   .inSingletonScope();
@@ -144,6 +156,11 @@ container
 container
   .bind(CHAT_ACCESS_REPOSITORY_ID)
   .to(SQLiteChatAccessRepository)
+  .inSingletonScope();
+
+container
+  .bind(CHAT_CONFIG_REPOSITORY_ID)
+  .to(SQLiteChatConfigRepository)
   .inSingletonScope();
 
 container.bind(ChatMemoryManager).toSelf().inSingletonScope();

--- a/src/repositories/interfaces/ChatConfigRepository.interface.ts
+++ b/src/repositories/interfaces/ChatConfigRepository.interface.ts
@@ -1,0 +1,16 @@
+import type { ServiceIdentifier } from 'inversify';
+
+export interface ChatConfigEntity {
+  chatId: number;
+  historyLimit: number;
+  interestInterval: number;
+}
+
+export interface ChatConfigRepository {
+  upsert(config: ChatConfigEntity): Promise<void>;
+  findById(chatId: number): Promise<ChatConfigEntity | undefined>;
+}
+
+export const CHAT_CONFIG_REPOSITORY_ID = Symbol.for(
+  'ChatConfigRepository'
+) as ServiceIdentifier<ChatConfigRepository>;

--- a/src/repositories/sqlite/SQLiteChatConfigRepository.ts
+++ b/src/repositories/sqlite/SQLiteChatConfigRepository.ts
@@ -1,0 +1,50 @@
+import { inject, injectable } from 'inversify';
+import type { Database } from 'sqlite';
+
+import { DB_PROVIDER_ID, type SQLiteDbProvider } from '../DbProvider';
+import {
+  type ChatConfigEntity,
+  type ChatConfigRepository,
+} from '../interfaces/ChatConfigRepository.interface';
+
+@injectable()
+export class SQLiteChatConfigRepository implements ChatConfigRepository {
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+
+  async upsert({
+    chatId,
+    historyLimit,
+    interestInterval,
+  }: ChatConfigEntity): Promise<void> {
+    const db = await this.db();
+    await db.run(
+      'INSERT INTO chat_configs (chat_id, history_limit, interest_interval) VALUES (?, ?, ?) ON CONFLICT(chat_id) DO UPDATE SET history_limit=excluded.history_limit, interest_interval=excluded.interest_interval',
+      chatId,
+      historyLimit,
+      interestInterval
+    );
+  }
+
+  async findById(chatId: number): Promise<ChatConfigEntity | undefined> {
+    const db = await this.db();
+    const row = await db.get<{
+      chat_id: number;
+      history_limit: number;
+      interest_interval: number;
+    }>(
+      'SELECT chat_id, history_limit, interest_interval FROM chat_configs WHERE chat_id = ?',
+      chatId
+    );
+    return row
+      ? {
+          chatId: row.chat_id,
+          historyLimit: row.history_limit,
+          interestInterval: row.interest_interval,
+        }
+      : undefined;
+  }
+
+  private async db(): Promise<Database> {
+    return this.dbProvider.get();
+  }
+}

--- a/src/services/chat/ChatConfigService.ts
+++ b/src/services/chat/ChatConfigService.ts
@@ -1,0 +1,53 @@
+import { inject, injectable, type ServiceIdentifier } from 'inversify';
+
+import {
+  CHAT_CONFIG_REPOSITORY_ID,
+  type ChatConfigEntity,
+  type ChatConfigRepository,
+} from '../../repositories/interfaces/ChatConfigRepository.interface';
+
+export interface ChatConfigService {
+  getConfig(chatId: number): Promise<ChatConfigEntity>;
+  setHistoryLimit(chatId: number, historyLimit: number): Promise<void>;
+  setInterestInterval(chatId: number, interestInterval: number): Promise<void>;
+}
+
+export const CHAT_CONFIG_SERVICE_ID = Symbol.for(
+  'ChatConfigService'
+) as ServiceIdentifier<ChatConfigService>;
+
+const DEFAULT_HISTORY_LIMIT = 50;
+const DEFAULT_INTEREST_INTERVAL = 25;
+
+@injectable()
+export class RepositoryChatConfigService implements ChatConfigService {
+  constructor(
+    @inject(CHAT_CONFIG_REPOSITORY_ID) private repo: ChatConfigRepository
+  ) {}
+
+  async getConfig(chatId: number): Promise<ChatConfigEntity> {
+    let config = await this.repo.findById(chatId);
+    if (!config) {
+      config = {
+        chatId,
+        historyLimit: DEFAULT_HISTORY_LIMIT,
+        interestInterval: DEFAULT_INTEREST_INTERVAL,
+      };
+      await this.repo.upsert(config);
+    }
+    return config;
+  }
+
+  async setHistoryLimit(chatId: number, historyLimit: number): Promise<void> {
+    const config = await this.getConfig(chatId);
+    await this.repo.upsert({ ...config, historyLimit });
+  }
+
+  async setInterestInterval(
+    chatId: number,
+    interestInterval: number
+  ): Promise<void> {
+    const config = await this.getConfig(chatId);
+    await this.repo.upsert({ ...config, interestInterval });
+  }
+}


### PR DESCRIPTION
## Summary
- add chat config repository and service
- store chat config in sqlite via DbProvider
- register chat config bindings in container

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a3100d02888327b4cdd1df225bea11