### PR TITLE
feat: enable admin chat config settings

### DIFF
--- a/src/bot/windowConfig.ts
+++ b/src/bot/windowConfig.ts
@@ -14,6 +14,8 @@ export type WindowId =
   | 'admin_menu'
   | 'admin_chats'
   | 'admin_chat'
+  | 'admin_chat_history_limit'
+  | 'admin_chat_interest_interval'
   | 'chat_not_approved'
   | 'no_access'
   | 'chat_approval_request'
@@ -123,7 +125,29 @@ export function createWindows(actions: WindowActions): RouteApi<WindowId>[] {
                 ? `chat_unban:${chatId}`
                 : `chat_ban:${chatId}`,
           }),
+          b({
+            text: '🕒 Лимит истории',
+            callback: `admin_chat_history_limit:${chatId}`,
+          }),
+          b({
+            text: '✨ Интервал интереса',
+            callback: `admin_chat_interest_interval:${chatId}`,
+          }),
         ],
+      };
+    }),
+    r('admin_chat_history_limit', async ({ loadData }) => {
+      const { chatId } = (await loadData()) as { chatId: number };
+      return {
+        text: `Введите новый лимит истории для чата ${chatId}:`,
+        buttons: [],
+      };
+    }),
+    r('admin_chat_interest_interval', async ({ loadData }) => {
+      const { chatId } = (await loadData()) as { chatId: number };
+      return {
+        text: `Введите новый интервал интереса для чата ${chatId}:`,
+        buttons: [],
       };
     }),
     r('chat_not_approved', async () => ({

--- a/src/services/admin/AdminService.interface.ts
+++ b/src/services/admin/AdminService.interface.ts
@@ -9,6 +9,8 @@ export interface AdminService {
   exportChatData(
     chatId: number
   ): Promise<{ filename: string; buffer: Buffer }[]>;
+  setHistoryLimit(chatId: number, value: number): Promise<void>;
+  setInterestInterval(chatId: number, value: number): Promise<void>;
 }
 
 import type { ServiceIdentifier } from 'inversify';

--- a/src/services/admin/AdminServiceImpl.ts
+++ b/src/services/admin/AdminServiceImpl.ts
@@ -29,6 +29,10 @@ import {
   type UserRepository,
 } from '../../repositories/interfaces/UserRepository.interface';
 import type { ChatMessage } from '../ai/AIService.interface';
+import {
+  CHAT_CONFIG_SERVICE_ID,
+  type ChatConfigService,
+} from '../chat/ChatConfigService';
 import { AdminService } from './AdminService.interface';
 
 @injectable()
@@ -40,7 +44,8 @@ export class AdminServiceImpl implements AdminService {
     @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository,
     @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository,
     @inject(CHAT_USER_REPOSITORY_ID) private chatUserRepo: ChatUserRepository,
-    @inject(USER_REPOSITORY_ID) private userRepo: UserRepository
+    @inject(USER_REPOSITORY_ID) private userRepo: UserRepository,
+    @inject(CHAT_CONFIG_SERVICE_ID) private chatConfig: ChatConfigService
   ) {}
 
   async createAccessKey(
@@ -134,6 +139,14 @@ export class AdminServiceImpl implements AdminService {
     }
 
     return files;
+  }
+
+  async setHistoryLimit(chatId: number, value: number): Promise<void> {
+    await this.chatConfig.setHistoryLimit(chatId, value);
+  }
+
+  async setInterestInterval(chatId: number, value: number): Promise<void> {
+    await this.chatConfig.setInterestInterval(chatId, value);
   }
 
   private async exportTable(

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -42,6 +42,8 @@ class DummyAdmin {
   exportTables = vi.fn(async () => []);
   exportChatData = vi.fn(async () => []);
   createAccessKey = vi.fn(async () => new Date());
+  setHistoryLimit = vi.fn(async () => {});
+  setInterestInterval = vi.fn(async () => {});
 }
 
 class DummyExtractor {
@@ -246,6 +248,212 @@ describe('TelegramBot', () => {
     expect(showSpy).toHaveBeenCalledWith(ctxText, 'menu');
   });
 
+  it('admin updates history limit on valid input', async () => {
+    const memories = new MockChatMemoryManager();
+    const admin = new DummyAdmin();
+    const bot = new TelegramBot(
+      new MockEnvService() as unknown as EnvService,
+      memories as unknown as ChatMemoryManager,
+      admin as unknown as AdminService,
+      new DummyApprovalService() as unknown as ChatApprovalService,
+      new DummyExtractor() as unknown as MessageContextExtractor,
+      new DummyPipeline() as unknown as TriggerPipeline,
+      new DummyResponder() as unknown as ChatResponder,
+      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatConfigService() as unknown as ChatConfigService
+    );
+    const showSpy = vi
+      .spyOn(
+        bot as unknown as {
+          showAdminChat: (ctx: Context, id: number) => Promise<void>;
+        },
+        'showAdminChat'
+      )
+      .mockResolvedValue(undefined);
+    await (
+      bot as unknown as {
+        handleAdminConfigHistoryLimit: (
+          ctx: Context,
+          chatId: number
+        ) => Promise<void>;
+      }
+    ).handleAdminConfigHistoryLimit(
+      {
+        chat: { id: 1 },
+        reply: vi.fn(),
+      } as Context,
+      42
+    );
+    const ctxText = {
+      chat: { id: 1 },
+      message: { text: '5' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxText);
+    expect(admin.setHistoryLimit).toHaveBeenCalledWith(42, 5);
+    expect(ctxText.reply).toHaveBeenCalledWith('✅ Лимит истории обновлён');
+    expect(showSpy).toHaveBeenCalledWith(ctxText, 42);
+  });
+
+  it('admin updates interest interval on valid input', async () => {
+    const memories = new MockChatMemoryManager();
+    const admin = new DummyAdmin();
+    const bot = new TelegramBot(
+      new MockEnvService() as unknown as EnvService,
+      memories as unknown as ChatMemoryManager,
+      admin as unknown as AdminService,
+      new DummyApprovalService() as unknown as ChatApprovalService,
+      new DummyExtractor() as unknown as MessageContextExtractor,
+      new DummyPipeline() as unknown as TriggerPipeline,
+      new DummyResponder() as unknown as ChatResponder,
+      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatConfigService() as unknown as ChatConfigService
+    );
+    const showSpy = vi
+      .spyOn(
+        bot as unknown as {
+          showAdminChat: (ctx: Context, id: number) => Promise<void>;
+        },
+        'showAdminChat'
+      )
+      .mockResolvedValue(undefined);
+    await (
+      bot as unknown as {
+        handleAdminConfigInterestInterval: (
+          ctx: Context,
+          chatId: number
+        ) => Promise<void>;
+      }
+    ).handleAdminConfigInterestInterval(
+      {
+        chat: { id: 1 },
+        reply: vi.fn(),
+      } as Context,
+      43
+    );
+    const ctxText = {
+      chat: { id: 1 },
+      message: { text: '10' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxText);
+    expect(admin.setInterestInterval).toHaveBeenCalledWith(43, 10);
+    expect(ctxText.reply).toHaveBeenCalledWith('✅ Интервал интереса обновлён');
+    expect(showSpy).toHaveBeenCalledWith(ctxText, 43);
+  });
+
+  it('admin handles invalid history limit input', async () => {
+    const memories = new MockChatMemoryManager();
+    const admin = new DummyAdmin();
+    const bot = new TelegramBot(
+      new MockEnvService() as unknown as EnvService,
+      memories as unknown as ChatMemoryManager,
+      admin as unknown as AdminService,
+      new DummyApprovalService() as unknown as ChatApprovalService,
+      new DummyExtractor() as unknown as MessageContextExtractor,
+      new DummyPipeline() as unknown as TriggerPipeline,
+      new DummyResponder() as unknown as ChatResponder,
+      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatConfigService() as unknown as ChatConfigService
+    );
+    const showSpy = vi
+      .spyOn(
+        bot as unknown as {
+          showAdminChat: (ctx: Context, id: number) => Promise<void>;
+        },
+        'showAdminChat'
+      )
+      .mockResolvedValue(undefined);
+    await (
+      bot as unknown as {
+        handleAdminConfigHistoryLimit: (
+          ctx: Context,
+          chatId: number
+        ) => Promise<void>;
+      }
+    ).handleAdminConfigHistoryLimit(
+      {
+        chat: { id: 1 },
+        reply: vi.fn(),
+      } as Context,
+      44
+    );
+    const ctxText = {
+      chat: { id: 1 },
+      message: { text: '100' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    admin.setHistoryLimit.mockImplementationOnce(async () => {
+      throw new InvalidHistoryLimitError('Invalid history limit');
+    });
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxText);
+    expect(admin.setHistoryLimit).toHaveBeenCalledWith(44, 100);
+    expect(ctxText.reply).toHaveBeenCalledWith(
+      '❌ Лимит истории должен быть целым числом от 1 до 50'
+    );
+    expect(showSpy).toHaveBeenCalledWith(ctxText, 44);
+  });
+
+  it('admin handles invalid interest interval input', async () => {
+    const memories = new MockChatMemoryManager();
+    const admin = new DummyAdmin();
+    const bot = new TelegramBot(
+      new MockEnvService() as unknown as EnvService,
+      memories as unknown as ChatMemoryManager,
+      admin as unknown as AdminService,
+      new DummyApprovalService() as unknown as ChatApprovalService,
+      new DummyExtractor() as unknown as MessageContextExtractor,
+      new DummyPipeline() as unknown as TriggerPipeline,
+      new DummyResponder() as unknown as ChatResponder,
+      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatConfigService() as unknown as ChatConfigService
+    );
+    const showSpy = vi
+      .spyOn(
+        bot as unknown as {
+          showAdminChat: (ctx: Context, id: number) => Promise<void>;
+        },
+        'showAdminChat'
+      )
+      .mockResolvedValue(undefined);
+    await (
+      bot as unknown as {
+        handleAdminConfigInterestInterval: (
+          ctx: Context,
+          chatId: number
+        ) => Promise<void>;
+      }
+    ).handleAdminConfigInterestInterval(
+      {
+        chat: { id: 1 },
+        reply: vi.fn(),
+      } as Context,
+      45
+    );
+    const ctxText = {
+      chat: { id: 1 },
+      message: { text: '100' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    admin.setInterestInterval.mockImplementationOnce(async () => {
+      throw new InvalidInterestIntervalError('Invalid interest interval');
+    });
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxText);
+    expect(admin.setInterestInterval).toHaveBeenCalledWith(45, 100);
+    expect(ctxText.reply).toHaveBeenCalledWith(
+      '❌ Интервал интереса должен быть целым числом от 1 до 50'
+    );
+    expect(showSpy).toHaveBeenCalledWith(ctxText, 45);
+  });
+
   it('stores user messages via ChatMemoryManager', async () => {
     const memories = new MockChatMemoryManager();
     const configureSpy = vi
@@ -410,7 +618,21 @@ describe('TelegramBot', () => {
     expect(ctx.deleteMessage).toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith('Статус чата 42: approved', {
       reply_markup: {
-        inline_keyboard: [[{ text: 'Забанить', callback_data: 'chat_ban:42' }]],
+        inline_keyboard: [
+          [{ text: 'Забанить', callback_data: 'chat_ban:42' }],
+          [
+            {
+              text: '🕒 Лимит истории',
+              callback_data: 'admin_chat_history_limit:42',
+            },
+          ],
+          [
+            {
+              text: '✨ Интервал интереса',
+              callback_data: 'admin_chat_interest_interval:42',
+            },
+          ],
+        ],
       },
     });
   });
@@ -534,6 +756,18 @@ describe('TelegramBot', () => {
       reply_markup: {
         inline_keyboard: [
           [{ text: 'Разбанить', callback_data: 'chat_unban:7' }],
+          [
+            {
+              text: '🕒 Лимит истории',
+              callback_data: 'admin_chat_history_limit:7',
+            },
+          ],
+          [
+            {
+              text: '✨ Интервал интереса',
+              callback_data: 'admin_chat_interest_interval:7',
+            },
+          ],
         ],
       },
     });


### PR DESCRIPTION
## Summary
- allow admins to set chat history limit and interest interval
- add admin UI routes and handlers for configuration
- cover admin configuration flows with unit tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a343169d908327a927030059aebb93