### PR TITLE
Add logger service for child loggers

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -68,6 +68,10 @@ import {
   INTEREST_CHECKER_ID,
 } from './services/interest/InterestChecker';
 import {
+  LOGGER_SERVICE_ID,
+  PinoLoggerService,
+} from './services/logging/LoggerService';
+import {
   INTEREST_MESSAGE_STORE_ID,
   InterestMessageStoreImpl,
 } from './services/messages/InterestMessageStore';
@@ -92,6 +96,8 @@ container
   .bind<EnvService>(ENV_SERVICE_ID)
   .to(EnvServiceImpl)
   .inSingletonScope();
+
+container.bind(LOGGER_SERVICE_ID).to(PinoLoggerService).inSingletonScope();
 
 container.bind(PROMPT_SERVICE_ID).to(FilePromptService).inSingletonScope();
 

--- a/src/services/logging/LoggerService.ts
+++ b/src/services/logging/LoggerService.ts
@@ -1,0 +1,27 @@
+import type { ServiceIdentifier } from 'inversify';
+import { injectable } from 'inversify';
+import type { ChildLoggerOptions, Logger as PinoLogger } from 'pino';
+
+import { logger } from './logger';
+
+export interface LoggerService {
+  create(meta: Record<string, unknown>): PinoLogger;
+}
+
+export const LOGGER_SERVICE_ID = Symbol.for(
+  'LoggerService'
+) as ServiceIdentifier<LoggerService>;
+
+const defaultBindings = { service: 'app' };
+
+const defaultOptions: ChildLoggerOptions = {
+  redact: [],
+  serializers: {},
+};
+
+@injectable()
+export class PinoLoggerService implements LoggerService {
+  create(meta: Record<string, unknown>): PinoLogger {
+    return logger.child({ ...defaultBindings, ...meta }, defaultOptions);
+  }
+}

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -28,4 +28,16 @@ describe('logger', () => {
     const { logger } = await import('../src/services/logging/logger');
     expect(logger).toBeDefined();
   });
+
+  it('creates child logger with service field', async () => {
+    process.env.NODE_ENV = 'test';
+    vi.resetModules();
+    const { container } = await import('../src/container');
+    const LoggerModule = await import('../src/services/logging/LoggerService');
+    const service = container.get<LoggerModule.LoggerService>(
+      LoggerModule.LOGGER_SERVICE_ID
+    );
+    const child = service.create({});
+    expect(child.bindings()).toHaveProperty('service');
+  });
 });


### PR DESCRIPTION
## Summary
- add injectable LoggerService interface and Pino implementation for creating child loggers
- bind LoggerService in the inversify container
- test LoggerService injection and child logger service field

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a345b65dbc8327a4138109dbaa5698