### PR TITLE
Refactor logging to factory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import http from 'node:http';
 
 import { TelegramBot } from './bot/TelegramBot';
 import { container } from './container';
-import { logger } from './services/logging/logger';
+import { createPinoLogger } from './services/logging/logger';
 
+const logger = createPinoLogger();
 const bot = container.get<TelegramBot>(TelegramBot);
 
 logger.info('Starting application');

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -6,7 +6,7 @@ import sqlite3 from 'sqlite3';
 import { container } from './container';
 import type { EnvService } from './services/env/EnvService';
 import { ENV_SERVICE_ID } from './services/env/EnvService';
-import { logger } from './services/logging/logger';
+import { createPinoLogger } from './services/logging/logger';
 import { parseDatabaseUrl } from './utils/database';
 
 interface Migration {
@@ -18,6 +18,7 @@ interface Migration {
 const envService = container.get<EnvService>(ENV_SERVICE_ID);
 const env = envService.env;
 const filename = parseDatabaseUrl(env.DATABASE_URL);
+const logger = createPinoLogger();
 
 function loadMigrations(dir = envService.getMigrationsDir()): Migration[] {
   logger.info({ dir }, 'Loading migrations from directory');

--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 
-import { logger } from '../logging/logger';
+import { createPinoLogger } from '../logging/logger';
 import {
   MESSAGE_SERVICE_ID,
   type MessageService,
@@ -13,13 +13,14 @@ import { ChatResetService } from './ChatResetService.interface';
 
 @injectable()
 export class DefaultChatResetService implements ChatResetService {
+  private readonly logger = createPinoLogger();
   constructor(
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
   ) {}
 
   async reset(chatId: number): Promise<void> {
-    logger.debug({ chatId }, 'Resetting chat data');
+    this.logger.debug({ chatId }, 'Resetting chat data');
     await this.messages.clearMessages(chatId);
     await this.summaries.clearSummary(chatId);
   }

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -2,7 +2,7 @@ import type { ServiceIdentifier } from 'inversify';
 import { inject, injectable } from 'inversify';
 
 import { ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
-import { logger } from '../logging/logger';
+import { createPinoLogger } from '../logging/logger';
 
 export interface DialogueManager {
   start(chatId: number): void;
@@ -18,18 +18,19 @@ export const DIALOGUE_MANAGER_ID = Symbol.for(
 export class DefaultDialogueManager implements DialogueManager {
   private timers = new Map<number, NodeJS.Timeout>();
   private timeoutMs: number;
+  private readonly logger = createPinoLogger();
 
   constructor(@inject(ENV_SERVICE_ID) envService: EnvService) {
     this.timeoutMs = envService.getDialogueTimeoutMs();
   }
 
   start(chatId: number): void {
-    logger.debug({ chatId }, 'Starting dialogue');
+    this.logger.debug({ chatId }, 'Starting dialogue');
     this.setTimer(chatId);
   }
 
   extend(chatId: number): void {
-    logger.debug({ chatId }, 'Extending dialogue');
+    this.logger.debug({ chatId }, 'Extending dialogue');
     this.setTimer(chatId);
   }
 
@@ -44,7 +45,7 @@ export class DefaultDialogueManager implements DialogueManager {
     }
     const timer = setTimeout(() => {
       this.timers.delete(chatId);
-      logger.debug({ chatId }, 'Dialogue timed out');
+      this.logger.debug({ chatId }, 'Dialogue timed out');
     }, this.timeoutMs);
     this.timers.set(chatId, timer);
   }

--- a/src/services/logging/LoggerService.ts
+++ b/src/services/logging/LoggerService.ts
@@ -2,7 +2,7 @@ import type { ServiceIdentifier } from 'inversify';
 import { injectable } from 'inversify';
 import type { ChildLoggerOptions, Logger as PinoLogger } from 'pino';
 
-import { logger } from './logger';
+import { createPinoLogger } from './logger';
 
 export interface LoggerService {
   create(meta: Record<string, unknown>): PinoLogger;
@@ -21,7 +21,12 @@ const defaultOptions: ChildLoggerOptions = {
 
 @injectable()
 export class PinoLoggerService implements LoggerService {
+  private readonly baseLogger = createPinoLogger();
+
   create(meta: Record<string, unknown>): PinoLogger {
-    return logger.child({ ...defaultBindings, ...meta }, defaultOptions);
+    return this.baseLogger.child(
+      { ...defaultBindings, ...meta },
+      defaultOptions
+    );
   }
 }

--- a/src/services/logging/logger.ts
+++ b/src/services/logging/logger.ts
@@ -4,15 +4,18 @@ import { DefaultEnvService, TestEnvService } from '../env/EnvService';
 
 const destination = pino.destination({ sync: false });
 
-const envService =
-  process.env.NODE_ENV === 'test'
-    ? new TestEnvService()
-    : new DefaultEnvService();
+export function createPinoLogger(
+  options: pino.LoggerOptions = {}
+): pino.Logger {
+  const envService =
+    process.env.NODE_ENV === 'test'
+      ? new TestEnvService()
+      : new DefaultEnvService();
 
-export const logger = pino(
-  {
+  const baseOptions: pino.LoggerOptions = {
     level: envService.env.LOG_LEVEL,
     transport: { target: 'pino-pretty' },
-  },
-  destination
-);
+  };
+
+  return pino({ ...baseOptions, ...options }, destination);
+}

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -17,12 +17,13 @@ import {
   type UserRepository,
 } from '../../repositories/interfaces/UserRepository.interface';
 import type { ChatMessage } from '../ai/AIService.interface';
-import { logger } from '../logging/logger';
+import { createPinoLogger } from '../logging/logger';
 import { MessageService } from './MessageService.interface';
 import { StoredMessage } from './StoredMessage.interface';
 
 @injectable()
 export class RepositoryMessageService implements MessageService {
+  private readonly logger = createPinoLogger();
   constructor(
     @inject(CHAT_REPOSITORY_ID) private chatRepo: ChatRepository,
     @inject(USER_REPOSITORY_ID) private userRepo: UserRepository,
@@ -31,7 +32,7 @@ export class RepositoryMessageService implements MessageService {
   ) {}
 
   async addMessage(message: StoredMessage): Promise<void> {
-    logger.debug(
+    this.logger.debug(
       { chatId: message.chatId, role: message.role },
       'Inserting message into database'
     );
@@ -54,22 +55,25 @@ export class RepositoryMessageService implements MessageService {
   }
 
   async getMessages(chatId: number): Promise<ChatMessage[]> {
-    logger.debug({ chatId }, 'Fetching messages from database');
+    this.logger.debug({ chatId }, 'Fetching messages from database');
     return this.messageRepo.findByChatId(chatId);
   }
 
   async getCount(chatId: number): Promise<number> {
-    logger.debug({ chatId }, 'Counting messages in database');
+    this.logger.debug({ chatId }, 'Counting messages in database');
     return this.messageRepo.countByChatId(chatId);
   }
 
   async getLastMessages(chatId: number, limit: number): Promise<ChatMessage[]> {
-    logger.debug({ chatId, limit }, 'Fetching last messages from database');
+    this.logger.debug(
+      { chatId, limit },
+      'Fetching last messages from database'
+    );
     return this.messageRepo.findLastByChatId(chatId, limit);
   }
 
   async clearMessages(chatId: number): Promise<void> {
-    logger.debug({ chatId }, 'Clearing messages table');
+    this.logger.debug({ chatId }, 'Clearing messages table');
     await this.messageRepo.clearByChatId(chatId);
   }
 }

--- a/src/services/prompts/FilePromptService.ts
+++ b/src/services/prompts/FilePromptService.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'inversify';
 
 import { createLazy } from '../../utils/lazy';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
-import { logger } from '../logging/logger';
+import { createPinoLogger } from '../logging/logger';
 import { PromptService } from './PromptService.interface';
 
 @injectable()
@@ -18,11 +18,12 @@ export class FilePromptService implements PromptService {
   private readonly assessUsersTemplate: () => Promise<string>;
   private readonly priorityRulesSystemTemplate: () => Promise<string>;
   private readonly replyTriggerTemplate: () => Promise<string>;
+  private readonly logger = createPinoLogger();
 
   constructor(@inject(ENV_SERVICE_ID) envService: EnvService) {
     const files = envService.getPromptFiles();
     this.persona = createLazy(async () => {
-      logger.debug('Loading persona file');
+      this.logger.debug('Loading persona file');
       return readFile(files.persona, 'utf-8');
     });
     this.askSummaryTemplate = createLazy(() =>

--- a/src/services/summaries/RepositorySummaryService.ts
+++ b/src/services/summaries/RepositorySummaryService.ts
@@ -4,27 +4,28 @@ import {
   SUMMARY_REPOSITORY_ID,
   type SummaryRepository,
 } from '../../repositories/interfaces/SummaryRepository.interface';
-import { logger } from '../logging/logger';
+import { createPinoLogger } from '../logging/logger';
 import { SummaryService } from './SummaryService.interface';
 
 @injectable()
 export class RepositorySummaryService implements SummaryService {
+  private readonly logger = createPinoLogger();
   constructor(
     @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository
   ) {}
 
   async getSummary(chatId: number): Promise<string> {
-    logger.debug({ chatId }, 'Fetching summary');
+    this.logger.debug({ chatId }, 'Fetching summary');
     return this.summaryRepo.findById(chatId);
   }
 
   async setSummary(chatId: number, summary: string): Promise<void> {
-    logger.debug({ chatId }, 'Storing summary');
+    this.logger.debug({ chatId }, 'Storing summary');
     await this.summaryRepo.upsert(chatId, summary);
   }
 
   async clearSummary(chatId: number): Promise<void> {
-    logger.debug({ chatId }, 'Clearing summary');
+    this.logger.debug({ chatId }, 'Clearing summary');
     await this.summaryRepo.clearByChatId(chatId);
   }
 }

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -2,7 +2,8 @@ import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
 import type { InterestChecker } from '../services/interest/InterestChecker';
-import { logger } from '../services/logging/logger';
+import { createPinoLogger } from '../services/logging/logger';
+const logger = createPinoLogger();
 import type {
   Trigger,
   TriggerContext,

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import { logger } from '../services/logging/logger';
+import { createPinoLogger } from '../services/logging/logger';
+const logger = createPinoLogger();
 import type {
   Trigger,
   TriggerContext,

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import { logger } from '../services/logging/logger';
+import { createPinoLogger } from '../services/logging/logger';
+const logger = createPinoLogger();
 import type {
   Trigger,
   TriggerContext,

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -1,7 +1,8 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import { logger } from '../services/logging/logger';
+import { createPinoLogger } from '../services/logging/logger';
+const logger = createPinoLogger();
 import type {
   Trigger,
   TriggerContext,

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage } from '../src/services/ai/AIService';
 import type { ChatGPTService as ChatGPTServiceType } from '../src/services/ai/ChatGPTService';
 import { TestEnvService } from '../src/services/env/EnvService';
-import { logger } from '../src/services/logging/logger';
 import type { PromptService } from '../src/services/prompts/PromptService';
 
 interface ChatGPTServiceConstructor {
@@ -121,9 +120,6 @@ describe('ChatGPTService', () => {
       ],
     });
 
-    const errorSpy = vi.fn<unknown[], unknown>();
-    (logger as unknown as { error: (...args: unknown[]) => unknown }).error =
-      errorSpy;
     openaiCreate.mockResolvedValueOnce({
       choices: [{ message: { content: 'not-json' } }],
     });
@@ -165,9 +161,6 @@ describe('ChatGPTService', () => {
       ],
     });
 
-    const errorSpy = vi.fn<unknown[], unknown>();
-    (logger as unknown as { error: (...args: unknown[]) => unknown }).error =
-      errorSpy;
     openaiCreate.mockResolvedValueOnce({
       choices: [{ message: { content: 'oops' } }],
     });

--- a/test/ChatResetService.test.ts
+++ b/test/ChatResetService.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageService } from '../src/services/messages/MessageService.interface';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
 
+const debug = vi.fn();
 vi.mock('../src/services/logging/logger', () => ({
-  logger: { debug: vi.fn() },
+  createPinoLogger: () => ({ debug }),
 }));
 
 import { DefaultChatResetService } from '../src/services/chat/DefaultChatResetService';
-import { logger } from '../src/services/logging/logger';
 
 describe('DefaultChatResetService', () => {
   const messages = {
@@ -31,9 +31,6 @@ describe('DefaultChatResetService', () => {
     await service.reset(chatId);
     expect(messages.clearMessages).toHaveBeenCalledWith(chatId);
     expect(summaries.clearSummary).toHaveBeenCalledWith(chatId);
-    expect(logger.debug).toHaveBeenCalledWith(
-      { chatId },
-      'Resetting chat data'
-    );
+    expect(debug).toHaveBeenCalledWith({ chatId }, 'Resetting chat data');
   });
 });

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -11,7 +11,8 @@ describe('logger', () => {
   it('creates logger in test env', async () => {
     process.env.NODE_ENV = 'test';
     vi.resetModules();
-    const { logger } = await import('../src/services/logging/logger');
+    const { createPinoLogger } = await import('../src/services/logging/logger');
+    const logger = createPinoLogger();
     expect(logger).toBeDefined();
   });
 
@@ -25,7 +26,8 @@ describe('logger', () => {
       ADMIN_CHAT_ID: '1',
     };
     vi.resetModules();
-    const { logger } = await import('../src/services/logging/logger');
+    const { createPinoLogger } = await import('../src/services/logging/logger');
+    const logger = createPinoLogger();
     expect(logger).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary
- replace global logger with createPinoLogger factory
- update services, triggers, and tests to use new logger factory

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a386b038a883278f33aef9eb5d74bd