### PR TITLE
Return interface-based logger from LoggerService

### DIFF
--- a/src/services/logging/LoggerService.ts
+++ b/src/services/logging/LoggerService.ts
@@ -1,32 +1,22 @@
 import type { ServiceIdentifier } from 'inversify';
 import { injectable } from 'inversify';
-import type { ChildLoggerOptions, Logger as PinoLogger } from 'pino';
 
 import { createPinoLogger } from './logger';
+import type Logger from './Logger.interface';
+import { PinoLogger } from './PinoLogger';
 
 export interface LoggerService {
-  create(meta: Record<string, unknown>): PinoLogger;
+  createLogger(): Logger;
 }
 
 export const LOGGER_SERVICE_ID = Symbol.for(
   'LoggerService'
 ) as ServiceIdentifier<LoggerService>;
 
-const defaultBindings = { service: 'app' };
-
-const defaultOptions: ChildLoggerOptions = {
-  redact: [],
-  serializers: {},
-};
-
 @injectable()
 export class PinoLoggerService implements LoggerService {
-  private readonly baseLogger = createPinoLogger();
-
-  create(meta: Record<string, unknown>): PinoLogger {
-    return this.baseLogger.child(
-      { ...defaultBindings, ...meta },
-      defaultOptions
-    );
+  createLogger(): Logger {
+    const logger = createPinoLogger();
+    return new PinoLogger(logger);
   }
 }

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -31,7 +31,7 @@ describe('logger', () => {
     expect(logger).toBeDefined();
   });
 
-  it('creates child logger with service field', async () => {
+  it('creates logger via service', async () => {
     process.env.NODE_ENV = 'test';
     vi.resetModules();
     const { container } = await import('../src/container');
@@ -39,7 +39,13 @@ describe('logger', () => {
     const service = container.get<LoggerModule.LoggerService>(
       LoggerModule.LOGGER_SERVICE_ID
     );
-    const child = service.create({});
-    expect(child.bindings()).toHaveProperty('service');
+    const logger = service.createLogger();
+    logger.debug('debug');
+    logger.info('info');
+    logger.warn('warn');
+    logger.error('error');
+    const child = logger.child({ service: 'test' });
+    child.info('child');
+    expect(typeof child.info).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- expose `createLogger` on `LoggerService`
- wrap Pino logger in `PinoLoggerService`
- update tests for new logger service API

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a48af5ccfc832790def1820e0d52f6