### PR TITLE
feat: log summary and message stats

### DIFF
--- a/src/services/chat/HistorySummarizer.ts
+++ b/src/services/chat/HistorySummarizer.ts
@@ -102,11 +102,18 @@ export class DefaultHistorySummarizer implements HistorySummarizer {
       'Generated new summary'
     );
 
+    const messagesDeleted = history.length;
     await this.summaries.setSummary(chatId, newSummary);
-    this.logger.debug({ chatId }, 'Stored new summary');
-
     await this.messages.clearMessages(chatId);
-    this.logger.debug({ chatId }, 'Cleared messages after summarization');
+    this.logger.debug(
+      {
+        chatId,
+        oldSummaryLength: summary.length,
+        newSummaryLength: newSummary.length,
+        messagesDeleted,
+      },
+      'Stored new summary and cleared messages'
+    );
     return true;
   }
 


### PR DESCRIPTION
## Summary
- log old and new summary lengths and count of messages cleared after summarization

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722a7297c8327b8e548e6abde528a