### PR TITLE
Log mention snippet and dialogue state

### DIFF
--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -66,6 +66,39 @@ describe('MentionTrigger', () => {
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
+
+  it('logs snippet and dialogue state', async () => {
+    const debug = vi.fn();
+    const loggerFactory = {
+      create: () => ({
+        debug,
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerFactory;
+    const triggerWithLogger = new MentionTrigger(loggerFactory);
+    const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
+    const telegrafCtx = {
+      message: { text: 'hello there @bot how are you doing?' },
+      me: 'bot',
+    } as unknown as Context;
+    const dialogue = new DefaultDialogueManager(
+      new TestEnvService(),
+      createLoggerFactory()
+    );
+    dialogue.start(1);
+    await triggerWithLogger.apply(telegrafCtx, ctx, dialogue);
+    expect(debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 1,
+        snippet: expect.stringContaining('@bot'),
+        dialogueState: 'active',
+      }),
+      'Mention trigger matched'
+    );
+  });
 });
 
 describe('NameTrigger', () => {


### PR DESCRIPTION
## Summary
- log message snippet around bot mentions
- record current dialogue state when mentions trigger
- test mention trigger logging

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722c0edd083279e8106e717358984