### PR TITLE
feat: log name trigger pattern and mismatch

### DIFF
--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -15,6 +15,10 @@ export class NameTrigger implements Trigger {
   constructor(name: string, loggerFactory: LoggerFactory) {
     this.pattern = new RegExp(`^${name}[,:\\s]`, 'i');
     this.logger = loggerFactory.create('NameTrigger');
+    this.logger.debug(
+      { pattern: this.pattern },
+      'Compiled name trigger pattern'
+    );
   }
   async apply(
     ctx: Context,
@@ -27,6 +31,10 @@ export class NameTrigger implements Trigger {
       this.logger.debug({ chatId: context.chatId }, 'Name trigger matched');
       return { replyToMessageId: null, reason: null };
     }
+    this.logger.debug(
+      { chatId: context.chatId, pattern: this.pattern, text },
+      'Name trigger not matched'
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- log compiled regex when NameTrigger is constructed
- debug log unmatched text when NameTrigger doesn't fire

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722c2422c83278ef7d2123ca576a5