### PR TITLE
build: add rsbuild config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -119,6 +119,7 @@ module.exports = [
       'eslint.config.cjs',
       'test/**',
       'vitest.config.ts',
+      'rsbuild.config.ts',
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@rsbuild/core": "^1.4.15",
+    "@rspack/core": "^1.4.11",
     "@swc-node/register": "^1.10.10",
     "@swc/cli": "^0.7.8",
     "@swc/core": "^1.12.11",

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,0 +1,24 @@
+/* eslint-disable import/no-unused-modules */
+import { defineConfig } from '@rsbuild/core';
+import { pluginNode } from '@rsbuild/plugin-node';
+import path from 'path';
+
+export const rsbuildConfig = defineConfig({
+  plugins: [pluginNode()],
+  target: 'node',
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    distPath: {
+      root: 'dist',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,5 +112,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["test", "vitest.config.ts", "node_modules"]
+  "exclude": ["test", "vitest.config.ts", "node_modules", "rsbuild.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add rsbuild configuration targeting Node with dist output and '@' alias
- install rsbuild and rspack build dependencies
- exclude rsbuild config from TypeScript and ESLint checks

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a85740d930832789e1f0d65465e5a1