### PR TITLE
feat: add chat info service

### DIFF
--- a/src/application/interfaces/chat/ChatInfoService.interface.ts
+++ b/src/application/interfaces/chat/ChatInfoService.interface.ts
@@ -1,0 +1,12 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { ChatEntity } from '@/domain/entities/ChatEntity';
+
+export interface ChatInfoService {
+  saveChat(chat: ChatEntity): Promise<void>;
+  getChat(chatId: number): Promise<ChatEntity | undefined>;
+}
+
+export const CHAT_INFO_SERVICE_ID = Symbol.for(
+  'ChatInfoService'
+) as ServiceIdentifier<ChatInfoService>;

--- a/src/application/use-cases/chat/RepositoryChatInfoService.ts
+++ b/src/application/use-cases/chat/RepositoryChatInfoService.ts
@@ -1,0 +1,21 @@
+import { inject, injectable } from 'inversify';
+
+import type { ChatInfoService } from '@/application/interfaces/chat/ChatInfoService.interface';
+import type { ChatEntity } from '@/domain/entities/ChatEntity';
+import {
+  CHAT_REPOSITORY_ID,
+  type ChatRepository,
+} from '@/domain/repositories/ChatRepository.interface';
+
+@injectable()
+export class RepositoryChatInfoService implements ChatInfoService {
+  constructor(@inject(CHAT_REPOSITORY_ID) private repo: ChatRepository) {}
+
+  async saveChat(chat: ChatEntity): Promise<void> {
+    await this.repo.upsert(chat);
+  }
+
+  async getChat(chatId: number): Promise<ChatEntity | undefined> {
+    return this.repo.findById(chatId);
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -20,6 +20,10 @@ import {
   type ChatConfigService,
 } from './application/interfaces/chat/ChatConfigService.interface';
 import {
+  CHAT_INFO_SERVICE_ID,
+  type ChatInfoService,
+} from './application/interfaces/chat/ChatInfoService.interface';
+import {
   CHAT_MEMORY_MANAGER_ID,
   type ChatMemoryManager as ChatMemoryManagerInterface,
 } from './application/interfaces/chat/ChatMemoryManager.interface';
@@ -84,6 +88,7 @@ import { DefaultDialogueManager } from './application/use-cases/chat/DefaultDial
 import { DefaultHistorySummarizer } from './application/use-cases/chat/DefaultHistorySummarizer';
 import { DefaultTriggerPipeline } from './application/use-cases/chat/DefaultTriggerPipeline';
 import { RepositoryChatConfigService } from './application/use-cases/chat/RepositoryChatConfigService';
+import { RepositoryChatInfoService } from './application/use-cases/chat/RepositoryChatInfoService';
 import { DefaultInterestChecker } from './application/use-cases/interest/DefaultInterestChecker';
 import { DefaultMessageContextExtractor } from './application/use-cases/messages/DefaultMessageContextExtractor';
 import { InMemoryInterestMessageStore } from './application/use-cases/messages/InMemoryInterestMessageStore';
@@ -196,6 +201,11 @@ container
 container
   .bind<ChatConfigService>(CHAT_CONFIG_SERVICE_ID)
   .to(RepositoryChatConfigService)
+  .inSingletonScope();
+
+container
+  .bind<ChatInfoService>(CHAT_INFO_SERVICE_ID)
+  .to(RepositoryChatInfoService)
   .inSingletonScope();
 
 container

--- a/src/view/telegram/TelegramBot.ts
+++ b/src/view/telegram/TelegramBot.ts
@@ -15,6 +15,10 @@ import {
 } from '@/application/interfaces/chat/ChatConfigService.errors';
 import type { ChatConfigService } from '@/application/interfaces/chat/ChatConfigService.interface';
 import { CHAT_CONFIG_SERVICE_ID } from '@/application/interfaces/chat/ChatConfigService.interface';
+import {
+  CHAT_INFO_SERVICE_ID,
+  type ChatInfoService,
+} from '@/application/interfaces/chat/ChatInfoService.interface';
 import type { ChatMemoryManager } from '@/application/interfaces/chat/ChatMemoryManager.interface';
 import { CHAT_MEMORY_MANAGER_ID } from '@/application/interfaces/chat/ChatMemoryManager.interface';
 import type { ChatResponder } from '@/application/interfaces/chat/ChatResponder.interface';
@@ -34,10 +38,6 @@ import {
 import type { MessageContextExtractor } from '@/application/interfaces/messages/MessageContextExtractor.interface';
 import { MESSAGE_CONTEXT_EXTRACTOR_ID } from '@/application/interfaces/messages/MessageContextExtractor.interface';
 import { MessageFactory } from '@/application/use-cases/messages/MessageFactory';
-import {
-  CHAT_REPOSITORY_ID,
-  type ChatRepository,
-} from '@/domain/repositories/ChatRepository.interface';
 import type { TriggerContext } from '@/domain/triggers/Trigger.interface';
 
 import { registerRoutes } from './telegramRouter';
@@ -84,7 +84,7 @@ export class TelegramBot {
     private extractor: MessageContextExtractor,
     @inject(TRIGGER_PIPELINE_ID) private pipeline: TriggerPipeline,
     @inject(CHAT_RESPONDER_ID) private responder: ChatResponder,
-    @inject(CHAT_REPOSITORY_ID) private chatRepo: ChatRepository,
+    @inject(CHAT_INFO_SERVICE_ID) private chatInfo: ChatInfoService,
     @inject(CHAT_CONFIG_SERVICE_ID) private chatConfig: ChatConfigService,
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
@@ -396,7 +396,7 @@ export class TelegramBot {
     const chats = await this.approvalService.listAll();
     return Promise.all(
       chats.map(async ({ chatId }) => {
-        const chat = await this.chatRepo.findById(chatId);
+        const chat = await this.chatInfo.getChat(chatId);
         return { id: chatId, title: chat?.title ?? 'Без названия' };
       })
     );

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { TelegramBot } from '../src/view/telegram/TelegramBot';
 import * as TelegramBotModule from '../src/view/telegram/TelegramBot';
 import { createWindows } from '../src/view/telegram/windowConfig';
-import type { ChatRepository } from '../src/domain/repositories/ChatRepository.interface';
+import type { ChatInfoService } from '../src/application/interfaces/chat/ChatInfoService.interface';
 import type { AdminService } from '../src/application/interfaces/admin/AdminService.interface';
 import type { ChatApprovalService } from '../src/application/interfaces/chat/ChatApprovalService.interface';
 import type { ChatMemoryManager } from '../src/application/interfaces/chat/ChatMemoryManager.interface';
@@ -82,9 +82,9 @@ class DummyApprovalService {
   pending = vi.fn(async () => {});
 }
 
-class DummyChatRepository {
-  upsert = vi.fn(async () => {});
-  findById = vi.fn(async () => undefined);
+class DummyChatInfoService {
+  saveChat = vi.fn(async () => {});
+  getChat = vi.fn(async () => undefined);
 }
 
 class DummyChatConfigService {
@@ -133,7 +133,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -166,7 +166,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -202,7 +202,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -238,7 +238,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -279,7 +279,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -320,7 +320,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -370,7 +370,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -420,7 +420,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -475,7 +475,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -542,7 +542,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -580,8 +580,8 @@ describe('TelegramBot', () => {
       { chatId: 42, status: 'approved' },
     ]);
 
-    const chatRepo = new DummyChatRepository();
-    chatRepo.findById.mockResolvedValue({ chatId: 42, title: 'Test Chat' });
+    const chatRepo = new DummyChatInfoService();
+    chatRepo.getChat.mockResolvedValue({ chatId: 42, title: 'Test Chat' });
 
     const actionSpy = vi.spyOn(Telegraf.prototype, 'action');
     const bot = new TelegramBot(
@@ -592,7 +592,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      chatRepo as unknown as ChatRepository,
+      chatRepo as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -624,7 +624,7 @@ describe('TelegramBot', () => {
     await handler(ctx);
 
     expect(approvalService.listAll).toHaveBeenCalled();
-    expect(chatRepo.findById).toHaveBeenCalledWith(42);
+    expect(chatRepo.getChat).toHaveBeenCalledWith(42);
     expect(ctx.reply).toHaveBeenCalledWith('Выберите чат для управления:', {
       reply_markup: {
         inline_keyboard: [
@@ -654,7 +654,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -731,7 +731,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -796,7 +796,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       config as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -880,7 +880,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -925,7 +925,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -973,7 +973,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1031,7 +1031,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1083,7 +1083,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1129,7 +1129,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1174,7 +1174,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1217,7 +1217,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1250,7 +1250,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1292,7 +1292,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1327,7 +1327,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1381,7 +1381,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );
@@ -1419,7 +1419,7 @@ describe('TelegramBot', () => {
       new DummyExtractor() as unknown as MessageContextExtractor,
       new DummyPipeline() as unknown as TriggerPipeline,
       new DummyResponder() as unknown as ChatResponder,
-      new DummyChatRepository() as unknown as ChatRepository,
+      new DummyChatInfoService() as unknown as ChatInfoService,
       new DummyChatConfigService() as unknown as ChatConfigService,
       createLoggerFactory()
     );


### PR DESCRIPTION
## Summary
- add ChatInfoService interface and repository-backed implementation
- use ChatInfoService in TelegramBot for chat lookups
- register ChatInfoService in DI container

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a872d7e7b48327b47f9f843636e3a1