### PR TITLE
Route OpenAI requests through RabbitMQ

### DIFF
--- a/src/domain/ai/OpenAI.ts
+++ b/src/domain/ai/OpenAI.ts
@@ -1,0 +1,46 @@
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+export const OPENAI_REQUEST_PRIORITY = {
+  generateMessage: 3,
+  summarizeHistory: 2,
+  checkInterest: 1,
+  assessUsers: 1,
+} as const;
+
+interface GenerateMessageRequestBody {
+  model: string;
+  messages: ChatCompletionMessageParam[];
+}
+
+interface SummarizeHistoryRequestBody {
+  model: string;
+  messages: ChatCompletionMessageParam[];
+}
+
+interface CheckInterestRequestBody {
+  model: string;
+  messages: ChatCompletionMessageParam[];
+}
+
+interface AssessUsersRequestBody {
+  model: string;
+  messages: ChatCompletionMessageParam[];
+}
+
+export type OpenAIRequest =
+  | { type: 'generateMessage'; body: GenerateMessageRequestBody }
+  | { type: 'summarizeHistory'; body: SummarizeHistoryRequestBody }
+  | { type: 'checkInterest'; body: CheckInterestRequestBody }
+  | { type: 'assessUsers'; body: AssessUsersRequestBody };
+// eslint-disable-next-line import/no-unused-modules
+export type OpenAIResponse =
+  | { type: 'generateMessage'; body: string }
+  | { type: 'summarizeHistory'; body: string }
+  | {
+      type: 'checkInterest';
+      body: { messageId: string; why: string } | null;
+    }
+  | {
+      type: 'assessUsers';
+      body: { username: string; attitude: string }[];
+    };

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -1,59 +1,42 @@
 import { promises as fs } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ChatMessage } from '../src/domain/messages/ChatMessage';
-import type { ChatGPTService as ChatGPTServiceType } from '../src/infrastructure/external/ChatGPTService';
-import { TestEnvService } from '../src/infrastructure/config/TestEnvService';
+import type { RabbitMQService } from '../src/application/interfaces/queue/RabbitMQService';
 import type { PromptService } from '../src/application/interfaces/prompts/PromptService';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory';
-
-interface ChatGPTServiceConstructor {
-  new (
-    env: TestEnvService,
-    prompts: PromptService,
-    logger: LoggerFactory
-  ): ChatGPTServiceType;
-}
+import { TestEnvService } from '../src/infrastructure/config/TestEnvService';
+import { ChatGPTService } from '../src/infrastructure/external/ChatGPTService';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage';
+import { OPENAI_REQUEST_PRIORITY } from '../src/domain/ai/OpenAI';
 
 describe('ChatGPTService', () => {
-  let ChatGPTService: ChatGPTServiceConstructor;
-  let service: ChatGPTServiceType;
-  let openaiCreate: ReturnType<typeof vi.fn<[], unknown>>;
+  let publish: ReturnType<typeof vi.fn>;
+  let service: ChatGPTService;
   let prompts: Record<string, unknown>;
   let env: TestEnvService;
-  let triggerPrompt: ReturnType<typeof vi.fn>;
   let loggerFactory: LoggerFactory;
 
   beforeEach(async () => {
     vi.resetModules();
-
-    openaiCreate = vi.fn<[], unknown>();
-    const openaiMock = { chat: { completions: { create: openaiCreate } } };
-    vi.doMock('openai', () => ({ default: vi.fn(() => openaiMock) }));
-
-    triggerPrompt = vi
-      .fn()
-      .mockImplementation(
-        async (w?: string, m?: string) => `trigger:${w}:${m}`
-      );
+    publish = vi.fn(async () => {});
+    const rabbit: RabbitMQService = {
+      publish: publish as unknown as RabbitMQService['publish'],
+      consume: vi.fn(),
+    };
 
     prompts = {
       getPersona: vi.fn().mockResolvedValue('persona'),
       getPriorityRulesSystemPrompt: vi.fn().mockResolvedValue('priority'),
       getUserPromptSystemPrompt: vi.fn().mockResolvedValue('userSystem'),
-      getAskSummaryPrompt: vi
-        .fn()
-        .mockImplementation(async (s: string) => `ask:${s}`),
+      getAskSummaryPrompt: vi.fn(async (s: string) => `ask:${s}`),
+      getTriggerPrompt: vi.fn(
+        async (w?: string, m?: string) => `trigger:${w}:${m}`
+      ),
+      getUserPrompt: vi.fn(async (c: string) => `user:${c}`),
       getInterestCheckPrompt: vi.fn().mockResolvedValue('interest'),
-      getUserPrompt: vi
-        .fn()
-        .mockImplementation(async (c: string) => `user:${c}`),
       getAssessUsersPrompt: vi.fn().mockResolvedValue('assess'),
       getSummarizationSystemPrompt: vi.fn().mockResolvedValue('sumSystem'),
-      getPreviousSummaryPrompt: vi
-        .fn()
-        .mockImplementation(async (p: string) => `prev:${p}`),
-      getTriggerPrompt: triggerPrompt,
+      getPreviousSummaryPrompt: vi.fn(async (p: string) => `prev:${p}`),
     };
 
     env = new TestEnvService();
@@ -66,25 +49,21 @@ describe('ChatGPTService', () => {
         child: vi.fn(),
       }),
     } as unknown as LoggerFactory;
-    ({ ChatGPTService } = await import(
-      '../src/infrastructure/external/ChatGPTService'
-    ));
+
     service = new ChatGPTService(
       env,
       prompts as unknown as PromptService,
-      loggerFactory
+      loggerFactory,
+      rabbit
     );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete process.env.LOG_PROMPTS;
+    delete (env.env as any).LOG_PROMPTS;
   });
 
-  it('ask forms messages and respects triggerReason', async () => {
-    openaiCreate.mockResolvedValue({
-      choices: [{ message: { content: 'resp' } }],
-    });
+  it('publishes generateMessage request', async () => {
     const history: ChatMessage[] = [
       {
         role: 'user',
@@ -98,184 +77,45 @@ describe('ChatGPTService', () => {
       },
       { role: 'assistant', content: 'yo' },
     ];
-    const triggerReason = { why: 'why', message: 'msg' };
-    const res = await service.ask(history, 'sum', triggerReason);
-    expect(res).toBe('resp');
-    expect(openaiCreate).toHaveBeenCalledTimes(1);
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().ask,
-      messages: [
-        { role: 'system', content: 'persona' },
-        { role: 'system', content: 'priority' },
-        { role: 'system', content: 'userSystem' },
-        { role: 'system', content: 'ask:sum' },
-        { role: 'system', content: 'trigger:why:msg' },
-        { role: 'user', content: 'user:hi' },
-        { role: 'assistant', content: 'yo' },
-      ],
-    });
-    expect(triggerPrompt).toHaveBeenCalledWith('why', 'msg');
-  });
-
-  it('checkInterest parses JSON response and handles errors', async () => {
-    openaiCreate.mockResolvedValue({
-      choices: [{ message: { content: '{"messageId":"1","why":"w"}' } }],
-    });
-    const history: ChatMessage[] = [
-      {
-        role: 'user',
-        content: 'm',
-        messageId: 1,
-        username: 'u',
-        fullName: 'U',
-      },
-    ];
-    const res = await service.checkInterest(history, '');
-    expect(res).toEqual({ messageId: '1', why: 'w' });
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().interest,
-      messages: [
-        { role: 'system', content: 'persona' },
-        { role: 'system', content: 'interest' },
-        { role: 'user', content: 'user:m' },
-      ],
-    });
-
-    openaiCreate.mockResolvedValueOnce({
-      choices: [{ message: { content: 'not-json' } }],
-    });
-    const res2 = await service.checkInterest(history, '');
-    expect(res2).toBeNull();
-  });
-
-  it('assessUsers adds previous attitudes and parses response', async () => {
-    openaiCreate.mockResolvedValue({
-      choices: [
-        {
-          message: { content: '[{"username":"u","attitude":"new"}]' },
-        },
-      ],
-    });
-    const history: ChatMessage[] = [
-      {
-        role: 'user',
-        content: 'h',
-        messageId: 1,
-        username: 'u',
-        fullName: 'U',
-      },
-    ];
-    const res = await service.assessUsers(history, [
-      { username: 'u', attitude: 'old' },
+    await service.ask(history, 'sum', { why: 'why', message: 'msg' });
+    expect(publish).toHaveBeenCalledTimes(1);
+    const [msg, priority] = publish.mock.calls[0];
+    expect(priority).toBe(OPENAI_REQUEST_PRIORITY.generateMessage);
+    const parsed = JSON.parse(msg as string);
+    expect(parsed.type).toBe('generateMessage');
+    expect(parsed.body.model).toBe(env.getModels().ask);
+    expect(parsed.body.messages).toEqual([
+      { role: 'system', content: 'persona' },
+      { role: 'system', content: 'priority' },
+      { role: 'system', content: 'userSystem' },
+      { role: 'system', content: 'ask:sum' },
+      { role: 'system', content: 'trigger:why:msg' },
+      { role: 'user', content: 'user:hi' },
+      { role: 'assistant', content: 'yo' },
     ]);
-    expect(res).toEqual([{ username: 'u', attitude: 'new' }]);
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().summary,
-      messages: [
-        { role: 'system', content: 'persona' },
-        { role: 'system', content: 'assess' },
-        {
-          role: 'system',
-          content: 'Предыдущее отношение бота к пользователям:\nu: old',
-        },
-        { role: 'user', content: 'user:h' },
-      ],
-    });
-
-    openaiCreate.mockResolvedValueOnce({
-      choices: [{ message: { content: 'oops' } }],
-    });
-    const res2 = await service.assessUsers(history);
-    expect(res2).toEqual([]);
   });
 
-  it('summarize builds history and uses previous summary', async () => {
-    openaiCreate.mockResolvedValueOnce({
-      choices: [{ message: { content: undefined } }],
-    });
-    const history: ChatMessage[] = [
-      {
-        role: 'user',
-        content: 'u1',
-        messageId: 1,
-        username: 'u',
-        fullName: 'U',
-      },
-      { role: 'assistant', content: 'a1' },
-    ];
-    const res = await service.summarize(history, 'prev');
-    expect(res).toBe('prev');
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().summary,
-      messages: [
-        { role: 'system', content: 'sumSystem' },
-        { role: 'user', content: 'prev:prev' },
-        {
-          role: 'user',
-          content: 'История диалога:\nuser:u1\nАссистент: a1',
-        },
-      ],
-    });
-  });
-
-  it('ask without optional params and summarize without prev', async () => {
-    openaiCreate.mockResolvedValueOnce({
-      choices: [{ message: { content: 'resp' } }],
-    });
-    const resAsk = await service.ask([]);
-    expect(resAsk).toBe('resp');
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().ask,
-      messages: [
-        { role: 'system', content: 'persona' },
-        { role: 'system', content: 'priority' },
-        { role: 'system', content: 'userSystem' },
-      ],
-    });
-
-    openaiCreate.mockResolvedValueOnce({
-      choices: [{ message: { content: 'sum' } }],
-    });
-    const resSum = await service.summarize([]);
-    expect(resSum).toBe('sum');
-    expect(openaiCreate).toHaveBeenCalledWith({
-      model: env.getModels().summary,
-      messages: [
-        { role: 'system', content: 'sumSystem' },
-        {
-          role: 'user',
-          content: 'История диалога:\n',
-        },
-      ],
-    });
+  it('publishes other request types', async () => {
+    await service.checkInterest([], '');
+    await service.assessUsers([], []);
+    await service.summarize([]);
+    expect(publish).toHaveBeenCalledTimes(3);
+    const types = publish.mock.calls.map(
+      (c) => JSON.parse(c[0] as string).type
+    );
+    expect(types).toEqual(['checkInterest', 'assessUsers', 'summarizeHistory']);
   });
 
   it('logPrompt writes only when LOG_PROMPTS=true', async () => {
-    openaiCreate.mockResolvedValue({
-      choices: [{ message: { content: 'r' } }],
-    });
-    const appendSpy = vi.spyOn(fs, 'appendFile').mockResolvedValue(undefined);
+    const appendSpy = vi.spyOn(fs, 'appendFile').mockResolvedValue();
 
-    const env1 = new TestEnvService();
-    (env1.env as unknown as { LOG_PROMPTS: boolean }).LOG_PROMPTS = false;
-    const service1 = new ChatGPTService(
-      env1,
-      prompts as unknown as PromptService,
-      loggerFactory
-    );
-    await service1.ask([]);
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await service.ask([]);
+    await new Promise((r) => setTimeout(r, 0));
     expect(appendSpy).not.toHaveBeenCalled();
 
-    const env2 = new TestEnvService();
-    (env2.env as unknown as { LOG_PROMPTS: boolean }).LOG_PROMPTS = true;
-    const service2 = new ChatGPTService(
-      env2,
-      prompts as unknown as PromptService,
-      loggerFactory
-    );
-    await service2.ask([]);
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    (env.env as any).LOG_PROMPTS = true;
+    await service.ask([]);
+    await new Promise((r) => setTimeout(r, 0));
     expect(appendSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add OpenAI request/response types with priorities
- publish OpenAI requests via RabbitMQ instead of direct SDK calls
- test ChatGPTService publishes correct OpenAI messages

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a917f33f1483278344339e651c81e6