### PR TITLE
Ensure message generation uses highest queue priority

### DIFF
--- a/src/infrastructure/external/ChatGPTService.ts
+++ b/src/infrastructure/external/ChatGPTService.ts
@@ -117,9 +117,10 @@ export class ChatGPTService implements AIService {
       },
     };
 
+    const highestPriority = Math.max(...Object.values(OPENAI_REQUEST_PRIORITY));
     const response = await this.rabbit.rpc<OpenAIRequest, OpenAIResponse>(
       request,
-      OPENAI_REQUEST_PRIORITY.generateMessage,
+      highestPriority,
       openAIResponseSchema
     );
     if (response.type !== 'generateMessage') {

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -88,7 +88,8 @@ describe('ChatGPTService', () => {
     expect(result).toBe('resp');
     expect(rpc).toHaveBeenCalledTimes(1);
     const [msg, priority] = rpc.mock.calls[0];
-    expect(priority).toBe(OPENAI_REQUEST_PRIORITY.generateMessage);
+    const highestPriority = Math.max(...Object.values(OPENAI_REQUEST_PRIORITY));
+    expect(priority).toBe(highestPriority);
     expect((msg as any).type).toBe('generateMessage');
     expect((msg as any).body.model).toBe(env.getModels().ask);
     expect((msg as any).body.messages).toEqual([


### PR DESCRIPTION
## Summary
- prioritize message generation requests by using the highest OpenAI queue priority
- verify priority handling in ChatGPTService unit test

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a9afc62a30832791b97ce0cf402078