### PR TITLE
Add PromptBuilder to compose prompt sections

### DIFF
--- a/src/application/interfaces/prompts/PromptBuilder.ts
+++ b/src/application/interfaces/prompts/PromptBuilder.ts
@@ -1,0 +1,15 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { UserEntity } from '@/domain/entities/UserEntity';
+
+export interface PromptBuilder {
+  addPersona(persona: string): this;
+  addUsers(users: UserEntity[]): this;
+  addRestrictions(restrictions: string[]): this;
+  addPart(part: string): this;
+  build(): Promise<string>;
+}
+
+export const PROMPT_BUILDER_ID = Symbol.for(
+  'PromptBuilder'
+) as ServiceIdentifier<PromptBuilder>;

--- a/src/application/services/prompts/PromptBuilder.ts
+++ b/src/application/services/prompts/PromptBuilder.ts
@@ -1,0 +1,73 @@
+import { inject, injectable } from 'inversify';
+
+import type { PromptBuilder as IPromptBuilder } from '@/application/interfaces/prompts/PromptBuilder';
+import type { PromptTemplateService } from '@/application/interfaces/prompts/PromptTemplateService';
+import { PROMPT_TEMPLATE_SERVICE_ID } from '@/application/interfaces/prompts/PromptTemplateService';
+import type { UserEntity } from '@/domain/entities/UserEntity';
+
+@injectable()
+export class PromptBuilder implements IPromptBuilder {
+  private persona?: string;
+  private users: UserEntity[] = [];
+  private restrictions: string[] = [];
+  private parts: string[] = [];
+
+  constructor(
+    @inject(PROMPT_TEMPLATE_SERVICE_ID)
+    private readonly templates: PromptTemplateService
+  ) {}
+
+  addPersona(persona: string): this {
+    this.persona = persona;
+    return this;
+  }
+
+  addUsers(users: UserEntity[]): this {
+    this.users.push(...users);
+    return this;
+  }
+
+  addRestrictions(restrictions: string[]): this {
+    this.restrictions.push(...restrictions);
+    return this;
+  }
+
+  addPart(part: string): this {
+    this.parts.push(part);
+    return this;
+  }
+
+  async build(): Promise<string> {
+    const sections: string[] = [];
+
+    if (this.persona) {
+      const tpl = await this.templates.getPersonaTemplate();
+      const replaced = tpl.replace('{{persona}}', this.persona);
+      sections.push(replaced);
+    }
+
+    if (this.users.length > 0) {
+      const tpl = await this.templates.getUsersTemplate();
+      const usersText = this.users
+        .map((u) => u.username ?? `id:${u.id}`)
+        .join(', ');
+      const replaced = tpl.replace('{{users}}', usersText);
+      sections.push(replaced);
+    }
+
+    if (this.restrictions.length > 0) {
+      const tpl = await this.templates.getRestrictionsTemplate();
+      const restrictionsText = this.restrictions
+        .map((r) => `- ${r}`)
+        .join('\n');
+      const replaced = tpl.replace('{{restrictions}}', restrictionsText);
+      sections.push(replaced);
+    }
+
+    if (this.parts.length > 0) {
+      sections.push(...this.parts);
+    }
+
+    return sections.join('\n\n');
+  }
+}

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -73,6 +73,10 @@ import {
   type MessageService,
 } from '../application/interfaces/messages/MessageService';
 import {
+  PROMPT_BUILDER_ID,
+  type PromptBuilder,
+} from '../application/interfaces/prompts/PromptBuilder';
+import {
   PROMPT_SERVICE_ID,
   type PromptService,
 } from '../application/interfaces/prompts/PromptService';
@@ -88,6 +92,7 @@ import {
   SUMMARY_SERVICE_ID,
   type SummaryService,
 } from '../application/interfaces/summaries/SummaryService';
+import { PromptBuilder as PromptBuilderImpl } from '../application/services/prompts/PromptBuilder';
 import { AdminServiceImpl } from '../application/use-cases/admin/AdminServiceImpl';
 import { ChatMemoryManager as ChatMemoryManagerImpl } from '../application/use-cases/chat/ChatMemory';
 import { DefaultChatApprovalService } from '../application/use-cases/chat/DefaultChatApprovalService';
@@ -135,6 +140,8 @@ export const register = (container: Container): void => {
     .bind<PromptService>(PROMPT_SERVICE_ID)
     .to(FilePromptService)
     .inSingletonScope();
+
+  container.bind<PromptBuilder>(PROMPT_BUILDER_ID).to(PromptBuilderImpl);
 
   container
     .bind<RabbitMQService>(RABBITMQ_SERVICE_ID)

--- a/test/PromptBuilder.test.ts
+++ b/test/PromptBuilder.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PromptTemplateService } from '../src/application/interfaces/prompts/PromptTemplateService';
+import { PromptBuilder } from '../src/application/services/prompts/PromptBuilder';
+import { UserEntity } from '../src/domain/entities/UserEntity';
+
+class StubTemplateService implements PromptTemplateService {
+  async getPersonaTemplate(): Promise<string> {
+    return 'persona: {{persona}}';
+  }
+  async getUsersTemplate(): Promise<string> {
+    return 'users: {{users}}';
+  }
+  async getRestrictionsTemplate(): Promise<string> {
+    return 'restrictions: {{restrictions}}';
+  }
+  async getAskSummaryTemplate(): Promise<string> {
+    return '';
+  }
+  async getSummarizationSystemTemplate(): Promise<string> {
+    return '';
+  }
+  async getPreviousSummaryTemplate(): Promise<string> {
+    return '';
+  }
+  async getInterestCheckTemplate(): Promise<string> {
+    return '';
+  }
+  async getUserPromptTemplate(): Promise<string> {
+    return '';
+  }
+  async getUserPromptSystemTemplate(): Promise<string> {
+    return '';
+  }
+  async getPriorityRulesSystemTemplate(): Promise<string> {
+    return '';
+  }
+  async getAssessUsersTemplate(): Promise<string> {
+    return '';
+  }
+  async getReplyTriggerTemplate(): Promise<string> {
+    return '';
+  }
+}
+
+describe('PromptBuilder', () => {
+  it('builds full prompt', async () => {
+    const builder = new PromptBuilder(new StubTemplateService());
+    const users = [new UserEntity(1, 'alice'), new UserEntity(2, 'bob')];
+    const prompt = await builder
+      .addPersona('test persona')
+      .addUsers(users)
+      .addRestrictions(['rule1', 'rule2'])
+      .addPart('extra')
+      .build();
+
+    expect(prompt).toBe(
+      'persona: test persona\n\nusers: alice, bob\n\nrestrictions: - rule1\n- rule2\n\nextra'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `PromptBuilder` interface and implementation to assemble persona, users and restrictions using prompt templates
- wire `PromptBuilder` into the application container
- cover `PromptBuilder` with unit test

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68adf84729ec8327a4b1ebecbce60c42