### PR TITLE
Allow route-specific cancel button in inline router

### DIFF
--- a/src/view/telegram/routerConfig.ts
+++ b/src/view/telegram/routerConfig.ts
@@ -112,6 +112,7 @@ const ChatSettings = route<Actions, ChatConfigParams>({
 
 const ChatHistoryLimit = route<Actions>({
   id: 'chat_history_limit',
+  showCancelOnWait: true,
   async action() {
     return { text: 'Введите новый лимит истории:', buttons: [] };
   },
@@ -126,6 +127,7 @@ const ChatHistoryLimit = route<Actions>({
 
 const ChatInterestInterval = route<Actions>({
   id: 'chat_interest_interval',
+  showCancelOnWait: true,
   async action() {
     return { text: 'Введите новый интервал интереса:', buttons: [] };
   },
@@ -140,6 +142,7 @@ const ChatInterestInterval = route<Actions>({
 
 const ChatTopicTime = route<Actions>({
   id: 'chat_topic_time',
+  showCancelOnWait: true,
   async action() {
     return { text: 'Введите время статьи (HH:MM):', buttons: [] };
   },
@@ -158,6 +161,7 @@ const ChatTopicTime = route<Actions>({
 
 const ChatTopicTimezone = route<Actions, { time: string; timezone: string }>({
   id: 'chat_topic_timezone',
+  showCancelOnWait: true,
   async action({ params }) {
     return {
       text: `Часовой пояс (${params.timezone}). Введите другой, если нужно:`,
@@ -285,6 +289,7 @@ const AdminChat = route<Actions, AdminChatParams | void>({
 
 const AdminChatHistoryLimit = route<Actions, { chatId: number } | void>({
   id: 'admin_chat_history_limit',
+  showCancelOnWait: true,
   async action({ ctx, params }) {
     if (!params) {
       const chatId = Number((ctx as Context & { match?: string[] }).match?.[1]);
@@ -309,6 +314,7 @@ const AdminChatHistoryLimit = route<Actions, { chatId: number } | void>({
 
 const AdminChatInterestInterval = route<Actions, { chatId: number } | void>({
   id: 'admin_chat_interest_interval',
+  showCancelOnWait: true,
   async action({ ctx, params }) {
     if (!params) {
       const chatId = Number((ctx as Context & { match?: string[] }).match?.[1]);
@@ -333,6 +339,7 @@ const AdminChatInterestInterval = route<Actions, { chatId: number } | void>({
 
 const AdminChatTopicTime = route<Actions, { chatId: number } | void>({
   id: 'admin_chat_topic_time',
+  showCancelOnWait: true,
   async action({ ctx, params }) {
     if (!params) {
       const chatId = Number((ctx as Context & { match?: string[] }).match?.[1]);
@@ -367,6 +374,7 @@ const AdminChatTopicTimezone = route<
   { chatId: number; time: string; timezone: string }
 >({
   id: 'admin_chat_topic_timezone',
+  showCancelOnWait: true,
   async action({ params }) {
     const { chatId, timezone } = params;
     return {

--- a/src/view/telegram/telegraf-inline-router.ts
+++ b/src/view/telegram/telegraf-inline-router.ts
@@ -86,6 +86,8 @@ export type Route<A = unknown, P = unknown> = {
   onText?: (
     args: RouteActionArgs<A, P> & { text: string }
   ) => Promise<void | RouteView<A>> | void | RouteView<A>;
+  /** Показывать кнопку «Отмена» при ожидании ввода текста для этого роута */
+  showCancelOnWait?: boolean;
 };
 
 /**
@@ -835,7 +837,11 @@ export function createRouter<A = unknown>(
 
     state.awaitingTextRouteId = undefined;
     await setState(ctx, state);
-    const showCancel = route.onText ? options.showCancelOnWait === true : false;
+    const showCancel = route.onText
+      ? typeof route.showCancelOnWait === 'boolean'
+        ? route.showCancelOnWait
+        : options.showCancelOnWait === true
+      : false;
     try {
       function navigateImpl<NP = unknown>(
         r: Route<A, NP>,
@@ -897,7 +903,11 @@ export function createRouter<A = unknown>(
     const route = e.route;
     const params = state.params[currentId];
     const inheritedShowBack = e.hasBackEffective && !!e.parentId;
-    const showCancel = route.onText ? options.showCancelOnWait === true : false;
+    const showCancel = route.onText
+      ? typeof route.showCancelOnWait === 'boolean'
+        ? route.showCancelOnWait
+        : options.showCancelOnWait === true
+      : false;
     try {
       function navigateImpl<NP = unknown>(
         r: Route<A, NP>,

--- a/test/view/telegram/telegrafInlineRouter.test.ts
+++ b/test/view/telegram/telegrafInlineRouter.test.ts
@@ -1,0 +1,108 @@
+import type { Context } from 'telegraf';
+import { Telegraf } from 'telegraf';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRouter,
+  route,
+} from '../../../src/view/telegram/telegraf-inline-router';
+
+describe('telegraf-inline-router', () => {
+  it('shows cancel on wait and hides it after text', async () => {
+    const r = route({
+      id: 'input',
+      showCancelOnWait: true,
+      async action() {
+        return { text: 'prompt', buttons: [] };
+      },
+      async onText() {
+        return { text: 'done', buttons: [] };
+      },
+    });
+    const { run } = createRouter([r], { showCancelOnWait: false });
+    const bot = new Telegraf<Context>('token');
+    const onSpy = vi.spyOn(bot, 'on');
+    const router = run(bot, {});
+    const textHandler = onSpy.mock.calls.find(([e]) => e === 'text')?.[1] as
+      | ((ctx: Context, next: () => Promise<void>) => Promise<void>)
+      | undefined;
+    onSpy.mockRestore();
+    if (!textHandler) throw new Error('text handler not registered');
+    const ctx = {
+      chat: { id: 1 },
+      from: { id: 1 },
+      reply: vi.fn(async () => ({ message_id: 1 })),
+      deleteMessage: vi.fn(async () => {}),
+      editMessageText: vi.fn(async () => {}),
+      editMessageReplyMarkup: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await router.navigate(ctx, r);
+    const firstKeyboard = (
+      ctx.reply.mock.calls[0][1] as {
+        reply_markup: { inline_keyboard: unknown[] };
+      }
+    ).reply_markup.inline_keyboard;
+    expect(firstKeyboard).toEqual([
+      [
+        expect.objectContaining({
+          text: '✖️ Отмена',
+          callback_data: '__router_cancel__',
+        }),
+      ],
+    ]);
+
+    const ctxText = {
+      ...ctx,
+      message: { text: 'hello', date: 0 },
+    } as Context & { message: { text: string; date: number } };
+    await textHandler(ctxText, async () => {});
+    const lastCall = ctx.reply.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe('done');
+    const lastKeyboard = (
+      lastCall?.[1] as {
+        reply_markup: { inline_keyboard: unknown[] };
+      }
+    ).reply_markup.inline_keyboard;
+    expect(lastKeyboard).toEqual([]);
+  });
+
+  it('allows overriding showBack and showCancel in view', async () => {
+    const r = route({
+      id: 'root',
+      async action() {
+        return { text: 'hello', buttons: [], showBack: true, showCancel: true };
+      },
+    });
+    const { run } = createRouter([r], { showCancelOnWait: false });
+    const bot = new Telegraf<Context>('token');
+    const router = run(bot, {});
+    const ctx = {
+      chat: { id: 1 },
+      from: { id: 1 },
+      reply: vi.fn(async () => ({ message_id: 1 })),
+      deleteMessage: vi.fn(async () => {}),
+      editMessageText: vi.fn(async () => {}),
+      editMessageReplyMarkup: vi.fn(async () => {}),
+    } as unknown as Context;
+
+    await router.navigate(ctx, r);
+    const kb = (
+      ctx.reply.mock.calls[0][1] as {
+        reply_markup: { inline_keyboard: unknown[] };
+      }
+    ).reply_markup.inline_keyboard;
+    expect(kb).toEqual([
+      [
+        expect.objectContaining({
+          text: '✖️ Отмена',
+          callback_data: '__router_cancel__',
+        }),
+        expect.objectContaining({
+          text: '⬅️ Назад',
+          callback_data: '__router_back__',
+        }),
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `showCancelOnWait` option per route in inline router
- enable cancel button on all text-input routes
- cover cancel/back overrides with new tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b023a6266483279fe02c6d82327fda