### PR TITLE
[codex] implement behavior executor phase 3

### DIFF
--- a/prompts/behavior_decision_system_prompt.md
+++ b/prompts/behavior_decision_system_prompt.md
@@ -7,6 +7,7 @@ Allowed visible/runtime actions: reply, react, ask_question, summarize_thread. A
 Allowed reaction emoji are exactly: 👍 👎 ❤️ 😂 😮 😢 😡 👏 🤔 🤝 💀 🤡 😭 🔥 👀 🙏 ✨ 🥹 🫶 🫠. Do not use other reaction emoji.
 
 Message selector scopes:
+
 - trigger: only messages marked [TRIGGER].
 - context: only messages marked [GATE_CONTEXT].
 - batch: only messages marked [BATCH].

--- a/prompts/behavior_decision_system_prompt.md
+++ b/prompts/behavior_decision_system_prompt.md
@@ -4,6 +4,15 @@ Return only the strict JSON object matching BehaviorDecision.
 
 Allowed visible/runtime actions: reply, react, ask_question, summarize_thread. An empty actions array is valid and means no visible action.
 
+Allowed reaction emoji are exactly: 👍 👎 ❤️ 😂 😮 😢 😡 👏 🤔 🤝 💀 🤡 😭 🔥 👀 🙏 ✨ 🥹 🫶 🫠. Do not use other reaction emoji.
+
+Message selector scopes:
+- trigger: only messages marked [TRIGGER].
+- context: only messages marked [GATE_CONTEXT].
+- batch: only messages marked [BATCH].
+
+For pick: first use the lowest storeId in that scope; latest use the highest storeId; index is zero-based in ascending storeId order; all selects every message in that scope.
+
 Allowed live state patches: user-profile patches and truth patches only. Do not propose personality or political patches in this live lane.
 
 Use evidence.messageIds from messages.id values visible in the prompt. Keep patch evidence small, specific, and tied to the triggering context.

--- a/src/application/behavior/BehaviorConfig.ts
+++ b/src/application/behavior/BehaviorConfig.ts
@@ -1,5 +1,8 @@
 import type { ServiceIdentifier } from 'inversify';
 
+import type { BehaviorDecisionValidatorConfig } from './BehaviorDecisionValidator';
+import type { PatchPolicyConfig } from './PatchPolicy';
+
 export interface BehaviorPipelineConfig {
   batchSizeCap: number;
   batchHardCapMs: number;
@@ -21,3 +24,50 @@ export const DEFAULT_BEHAVIOR_PIPELINE_CONFIG: BehaviorPipelineConfig = {
 export const BEHAVIOR_PIPELINE_CONFIG_ID = Symbol.for(
   'BehaviorPipelineConfig'
 ) as ServiceIdentifier<BehaviorPipelineConfig>;
+
+export const DEFAULT_BEHAVIOR_DECISION_VALIDATOR_CONFIG: BehaviorDecisionValidatorConfig =
+  {
+    maxReplyLength: 2_000,
+    allowedEmoji: [
+      '👍',
+      '👎',
+      '❤️',
+      '😂',
+      '😮',
+      '😢',
+      '😡',
+      '👏',
+      '🤔',
+      '🤝',
+      '💀',
+      '🤡',
+      '😭',
+      '🔥',
+      '👀',
+      '🙏',
+      '✨',
+      '🥹',
+      '🫶',
+      '🫠',
+    ],
+  };
+
+export const BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID = Symbol.for(
+  'BehaviorDecisionValidatorConfig'
+) as ServiceIdentifier<BehaviorDecisionValidatorConfig>;
+
+export const DEFAULT_PATCH_POLICY_CONFIG: PatchPolicyConfig = {
+  personalityMinConfidence: 0.5,
+  politicalWeakMaxConfidence: 0.4,
+  politicalStrongMinConfidence: 0.7,
+  hardBoundaryTerms: [
+    'credible threat',
+    'real-world violence',
+    'dehumanization',
+    'targeted harassment',
+  ],
+};
+
+export const PATCH_POLICY_CONFIG_ID = Symbol.for(
+  'PatchPolicyConfig'
+) as ServiceIdentifier<PatchPolicyConfig>;

--- a/src/application/behavior/BehaviorConfig.ts
+++ b/src/application/behavior/BehaviorConfig.ts
@@ -71,3 +71,25 @@ export const DEFAULT_PATCH_POLICY_CONFIG: PatchPolicyConfig = {
 export const PATCH_POLICY_CONFIG_ID = Symbol.for(
   'PatchPolicyConfig'
 ) as ServiceIdentifier<PatchPolicyConfig>;
+
+export interface BehaviorRateLimiterConfig {
+  initiativeWindowMs: number;
+  maxInitiativesPerWindow: number;
+  reactionWindowMs: number;
+  maxReactionsPerWindow: number;
+  truthAddWindowMs: number;
+  maxTruthAddsPerWindow: number;
+}
+
+export const DEFAULT_BEHAVIOR_RATE_LIMITER_CONFIG: BehaviorRateLimiterConfig = {
+  initiativeWindowMs: 60_000,
+  maxInitiativesPerWindow: 3,
+  reactionWindowMs: 60_000,
+  maxReactionsPerWindow: 8,
+  truthAddWindowMs: 10 * 60_000,
+  maxTruthAddsPerWindow: 3,
+};
+
+export const BEHAVIOR_RATE_LIMITER_CONFIG_ID = Symbol.for(
+  'BehaviorRateLimiterConfig'
+) as ServiceIdentifier<BehaviorRateLimiterConfig>;

--- a/src/application/behavior/BehaviorConfig.ts
+++ b/src/application/behavior/BehaviorConfig.ts
@@ -93,3 +93,16 @@ export const DEFAULT_BEHAVIOR_RATE_LIMITER_CONFIG: BehaviorRateLimiterConfig = {
 export const BEHAVIOR_RATE_LIMITER_CONFIG_ID = Symbol.for(
   'BehaviorRateLimiterConfig'
 ) as ServiceIdentifier<BehaviorRateLimiterConfig>;
+
+export interface BehaviorSummarizationQueueConfig {
+  enabled: boolean;
+}
+
+export const DEFAULT_BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG: BehaviorSummarizationQueueConfig =
+  {
+    enabled: true,
+  };
+
+export const BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG_ID = Symbol.for(
+  'BehaviorSummarizationQueueConfig'
+) as ServiceIdentifier<BehaviorSummarizationQueueConfig>;

--- a/src/application/behavior/BehaviorContextAssembler.ts
+++ b/src/application/behavior/BehaviorContextAssembler.ts
@@ -6,6 +6,7 @@ export interface BehaviorContextAssemblerInput {
   chatId: number;
   triggerMessageIds: number[];
   contextMessageIds: number[];
+  batchMessageIds: number[];
   gate: BehaviorDecisionContext['gate'];
 }
 

--- a/src/application/behavior/BehaviorEventLogger.ts
+++ b/src/application/behavior/BehaviorEventLogger.ts
@@ -1,14 +1,18 @@
 import type { ServiceIdentifier } from 'inversify';
 
 import type {
+  BehaviorActionResult,
   BehaviorAiDecisionResult,
   BehaviorDecisionContext,
+  BehaviorPatchResult,
 } from './BehaviorTypes';
 
 export interface BehaviorEventLogger {
   logDecision(params: {
     context: BehaviorDecisionContext;
     result: BehaviorAiDecisionResult;
+    actionResults?: BehaviorActionResult[];
+    patchResults?: BehaviorPatchResult[];
   }): Promise<number>;
 }
 

--- a/src/application/behavior/BehaviorExecutor.ts
+++ b/src/application/behavior/BehaviorExecutor.ts
@@ -1,0 +1,17 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
+
+import type { BehaviorActionResult, BehaviorDecisionContext } from './BehaviorTypes';
+
+export interface BehaviorExecutor {
+  execute(params: {
+    context: BehaviorDecisionContext;
+    actions: readonly BehaviorAction[];
+    nowMs?: number;
+  }): Promise<BehaviorActionResult[]>;
+}
+
+export const BEHAVIOR_EXECUTOR_ID = Symbol.for(
+  'BehaviorExecutor'
+) as ServiceIdentifier<BehaviorExecutor>;

--- a/src/application/behavior/BehaviorExecutor.ts
+++ b/src/application/behavior/BehaviorExecutor.ts
@@ -2,7 +2,10 @@ import type { ServiceIdentifier } from 'inversify';
 
 import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
 
-import type { BehaviorActionResult, BehaviorDecisionContext } from './BehaviorTypes';
+import type {
+  BehaviorActionResult,
+  BehaviorDecisionContext,
+} from './BehaviorTypes';
 
 export interface BehaviorExecutor {
   execute(params: {

--- a/src/application/behavior/BehaviorRateLimiter.ts
+++ b/src/application/behavior/BehaviorRateLimiter.ts
@@ -1,0 +1,31 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
+import type { LiveStatePatch } from '@/domain/behavior/schemas/patches';
+
+export type BehaviorRateLimitResult =
+  | {
+      allowed: true;
+    }
+  | {
+      allowed: false;
+      reason: string;
+    };
+
+export interface BehaviorRateLimiter {
+  checkAction(params: {
+    chatId: number;
+    action: BehaviorAction;
+    nowMs?: number;
+  }): BehaviorRateLimitResult;
+
+  checkPatch(params: {
+    chatId: number;
+    patch: LiveStatePatch;
+    nowMs?: number;
+  }): BehaviorRateLimitResult;
+}
+
+export const BEHAVIOR_RATE_LIMITER_ID = Symbol.for(
+  'BehaviorRateLimiter'
+) as ServiceIdentifier<BehaviorRateLimiter>;

--- a/src/application/behavior/BehaviorSummarizationQueue.ts
+++ b/src/application/behavior/BehaviorSummarizationQueue.ts
@@ -1,0 +1,34 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
+
+export interface BehaviorSummarizationRequest {
+  chatId: number;
+  intent: Extract<BehaviorAction, { type: 'summarize_thread' }>['intent'];
+  reason: string;
+  triggerMessageIds: number[];
+  contextMessageIds: number[];
+  batchMessageIds: number[];
+}
+
+export type BehaviorSummarizationQueueResult =
+  | {
+      outcome: 'queued';
+    }
+  | {
+      outcome: 'bumped';
+    }
+  | {
+      outcome: 'deferred';
+      reason: string;
+    };
+
+export interface BehaviorSummarizationQueue {
+  enqueueOrBump(
+    request: BehaviorSummarizationRequest
+  ): BehaviorSummarizationQueueResult;
+}
+
+export const BEHAVIOR_SUMMARIZATION_QUEUE_ID = Symbol.for(
+  'BehaviorSummarizationQueue'
+) as ServiceIdentifier<BehaviorSummarizationQueue>;

--- a/src/application/behavior/BehaviorTypes.ts
+++ b/src/application/behavior/BehaviorTypes.ts
@@ -1,11 +1,13 @@
 import type { ChatModel } from 'openai/resources/shared';
 
 import type { BehaviorPromptContext } from '@/application/prompts/PromptTypes';
+import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
 import type { BehaviorDecision } from '@/domain/behavior/schemas/decision';
 import type {
   BehaviorGateDecision,
   GateReason,
 } from '@/domain/behavior/schemas/gate';
+import type { LiveStatePatch } from '@/domain/behavior/schemas/patches';
 import type { ChatMessage } from '@/domain/messages/ChatMessage';
 
 export interface StoredBehaviorMessage extends ChatMessage {
@@ -48,4 +50,47 @@ export interface GateAiResult {
 export interface BehaviorAiDecisionResult {
   decision: BehaviorDecision;
   metadata: AiCallMetadata;
+}
+
+export type BehaviorActionOutcome =
+  | 'sent'
+  | 'queued'
+  | 'bumped'
+  | 'deferred'
+  | 'dropped'
+  | 'rate_limited'
+  | 'failed'
+  | 'skipped';
+
+export interface BehaviorActionResult {
+  actionType: BehaviorAction['type'];
+  outcome: BehaviorActionOutcome;
+  reason: string | null;
+  targetMessageId?: number | null;
+  telegramMessageId?: number | null;
+}
+
+export type BehaviorPatchOutcome =
+  | 'applied'
+  | 'rejected'
+  | 'rate_limited'
+  | 'failed';
+
+export type BehaviorPatchStateRef =
+  | {
+      kind: 'user_social_profile';
+      chatId: number;
+      userId: number;
+    }
+  | {
+      kind: 'bot_truth';
+      chatId: number;
+      truthId: number;
+    };
+
+export interface BehaviorPatchResult {
+  patchType: LiveStatePatch['type'];
+  outcome: BehaviorPatchOutcome;
+  reason: string | null;
+  stateRef?: BehaviorPatchStateRef | null;
 }

--- a/src/application/behavior/DefaultBehaviorContextAssembler.ts
+++ b/src/application/behavior/DefaultBehaviorContextAssembler.ts
@@ -98,7 +98,11 @@ export class DefaultBehaviorContextAssembler implements BehaviorContextAssembler
     } = input;
 
     const selectedIds = [
-      ...new Set([...triggerMessageIds, ...contextMessageIds, ...batchMessageIds]),
+      ...new Set([
+        ...triggerMessageIds,
+        ...contextMessageIds,
+        ...batchMessageIds,
+      ]),
     ];
 
     const [

--- a/src/application/behavior/DefaultBehaviorContextAssembler.ts
+++ b/src/application/behavior/DefaultBehaviorContextAssembler.ts
@@ -89,10 +89,16 @@ export class DefaultBehaviorContextAssembler implements BehaviorContextAssembler
   async assemble(
     input: BehaviorContextAssemblerInput
   ): Promise<BehaviorDecisionContext> {
-    const { chatId, triggerMessageIds, contextMessageIds, gate } = input;
+    const {
+      batchMessageIds = [],
+      chatId,
+      contextMessageIds,
+      gate,
+      triggerMessageIds,
+    } = input;
 
     const selectedIds = [
-      ...new Set([...triggerMessageIds, ...contextMessageIds]),
+      ...new Set([...triggerMessageIds, ...contextMessageIds, ...batchMessageIds]),
     ];
 
     const [
@@ -133,6 +139,7 @@ export class DefaultBehaviorContextAssembler implements BehaviorContextAssembler
       messages: mergedMessages,
       triggerMessageIds,
       contextMessageIds,
+      batchMessageIds,
       state: {
         personality: personality ?? defaultPersonality(chatId, now),
         political: political ?? defaultPolitical(chatId, now),

--- a/src/application/behavior/DefaultBehaviorDecisionValidator.ts
+++ b/src/application/behavior/DefaultBehaviorDecisionValidator.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import type {
   BehaviorAction,
@@ -13,6 +13,7 @@ import type {
   BehaviorDecisionValidatorConfig,
   DroppedAction,
 } from './BehaviorDecisionValidator';
+import { BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID } from './BehaviorConfig';
 
 function selectorKey(selector: MessageSelector): string {
   return `${selector.scope}:${selector.pick}:${selector.index ?? ''}`;
@@ -20,7 +21,10 @@ function selectorKey(selector: MessageSelector): string {
 
 @injectable()
 export class DefaultBehaviorDecisionValidator implements BehaviorDecisionValidator {
-  constructor(private readonly config: BehaviorDecisionValidatorConfig) {}
+  constructor(
+    @inject(BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID)
+    private readonly config: BehaviorDecisionValidatorConfig
+  ) {}
 
   validate(raw: unknown): BehaviorDecisionValidationResult {
     const parsed = behaviorDecisionSchema.safeParse(raw);

--- a/src/application/behavior/DefaultBehaviorEventLogger.ts
+++ b/src/application/behavior/DefaultBehaviorEventLogger.ts
@@ -7,8 +7,10 @@ import {
 
 import type { BehaviorEventLogger } from './BehaviorEventLogger';
 import type {
+  BehaviorActionResult,
   BehaviorAiDecisionResult,
   BehaviorDecisionContext,
+  BehaviorPatchResult,
 } from './BehaviorTypes';
 
 @injectable()
@@ -21,8 +23,10 @@ export class DefaultBehaviorEventLogger implements BehaviorEventLogger {
   async logDecision(params: {
     context: BehaviorDecisionContext;
     result: BehaviorAiDecisionResult;
+    actionResults?: BehaviorActionResult[];
+    patchResults?: BehaviorPatchResult[];
   }): Promise<number> {
-    const { context, result } = params;
+    const { actionResults = [], context, patchResults = [], result } = params;
     const { gate } = context;
     const { decision, metadata } = result;
     const now = new Date().toISOString();
@@ -40,9 +44,9 @@ export class DefaultBehaviorEventLogger implements BehaviorEventLogger {
       escalated: metadata.escalated,
       escalationReason: metadata.escalationReason,
       actionsJson: JSON.stringify(decision.actions),
-      actionResultsJson: JSON.stringify([]),
+      actionResultsJson: JSON.stringify(actionResults),
       statePatchesJson: JSON.stringify(decision.statePatches),
-      patchResultsJson: JSON.stringify([]),
+      patchResultsJson: JSON.stringify(patchResults),
       confidence: decision.confidence,
       promptTokens: metadata.usage.promptTokens,
       completionTokens: metadata.usage.completionTokens,

--- a/src/application/behavior/DefaultBehaviorExecutor.ts
+++ b/src/application/behavior/DefaultBehaviorExecutor.ts
@@ -20,7 +20,10 @@ import {
   BEHAVIOR_SUMMARIZATION_QUEUE_ID,
   type BehaviorSummarizationQueue,
 } from './BehaviorSummarizationQueue';
-import type { BehaviorActionResult, BehaviorDecisionContext } from './BehaviorTypes';
+import type {
+  BehaviorActionResult,
+  BehaviorDecisionContext,
+} from './BehaviorTypes';
 
 interface ResolvedMessageTarget {
   storedMessageId: number;
@@ -253,7 +256,10 @@ export class DefaultBehaviorExecutor implements BehaviorExecutor {
     context: BehaviorDecisionContext,
     selector: MessageSelector | SingleMessageSelector
   ): ResolvedMessageTarget[] {
-    const selectedIds = this.selectIds(this.scopeIds(context, selector.scope), selector);
+    const selectedIds = this.selectIds(
+      this.scopeIds(context, selector.scope),
+      selector
+    );
     const messagesById = new Map(
       context.messages.map((message) => [message.id, message])
     );

--- a/src/application/behavior/DefaultBehaviorExecutor.ts
+++ b/src/application/behavior/DefaultBehaviorExecutor.ts
@@ -1,0 +1,328 @@
+import { inject, injectable } from 'inversify';
+
+import {
+  CHAT_MESSENGER_ID,
+  type ChatMessenger,
+} from '@/application/interfaces/chat/ChatMessenger';
+import type {
+  BehaviorAction,
+  MessageSelector,
+  ReplyTarget,
+  SingleMessageSelector,
+} from '@/domain/behavior/schemas/actions';
+
+import {
+  BEHAVIOR_RATE_LIMITER_ID,
+  type BehaviorRateLimiter,
+} from './BehaviorRateLimiter';
+import type { BehaviorExecutor } from './BehaviorExecutor';
+import {
+  BEHAVIOR_SUMMARIZATION_QUEUE_ID,
+  type BehaviorSummarizationQueue,
+} from './BehaviorSummarizationQueue';
+import type { BehaviorActionResult, BehaviorDecisionContext } from './BehaviorTypes';
+
+interface ResolvedMessageTarget {
+  storedMessageId: number;
+  telegramMessageId: number | null;
+}
+
+@injectable()
+export class DefaultBehaviorExecutor implements BehaviorExecutor {
+  constructor(
+    @inject(CHAT_MESSENGER_ID) private readonly messenger: ChatMessenger,
+    @inject(BEHAVIOR_RATE_LIMITER_ID)
+    private readonly rateLimiter: BehaviorRateLimiter,
+    @inject(BEHAVIOR_SUMMARIZATION_QUEUE_ID)
+    private readonly summarizationQueue: BehaviorSummarizationQueue
+  ) {}
+
+  async execute(params: {
+    context: BehaviorDecisionContext;
+    actions: readonly BehaviorAction[];
+    nowMs?: number;
+  }): Promise<BehaviorActionResult[]> {
+    const results: BehaviorActionResult[] = [];
+
+    for (const action of params.actions) {
+      const rateLimit = this.rateLimiter.checkAction({
+        chatId: params.context.chatId,
+        action,
+        nowMs: params.nowMs,
+      });
+
+      if (!rateLimit.allowed) {
+        results.push({
+          actionType: action.type,
+          outcome: 'rate_limited',
+          reason: rateLimit.reason,
+        });
+        continue;
+      }
+
+      results.push(...(await this.executeAction(params.context, action)));
+    }
+
+    return results;
+  }
+
+  private async executeAction(
+    context: BehaviorDecisionContext,
+    action: BehaviorAction
+  ): Promise<BehaviorActionResult[]> {
+    switch (action.type) {
+      case 'reply':
+        return [await this.executeReply(context, action)];
+      case 'ask_question':
+        return [await this.executeAskQuestion(context, action)];
+      case 'react':
+        return this.executeReact(context, action);
+      case 'summarize_thread':
+        return [this.executeSummarizeThread(context, action)];
+    }
+  }
+
+  private async executeReply(
+    context: BehaviorDecisionContext,
+    action: Extract<BehaviorAction, { type: 'reply' }>
+  ): Promise<BehaviorActionResult> {
+    const target = this.resolveReplyTarget(context, action.target);
+    if (target.outcome !== 'resolved') {
+      return {
+        actionType: action.type,
+        outcome: 'dropped',
+        reason: target.reason,
+        targetMessageId: target.targetMessageId,
+      };
+    }
+
+    const extra =
+      target.telegramMessageId === null
+        ? undefined
+        : { reply_parameters: { message_id: target.telegramMessageId } };
+
+    try {
+      await this.messenger.sendMessage(context.chatId, action.text, extra);
+      return {
+        actionType: action.type,
+        outcome: 'sent',
+        reason: null,
+        targetMessageId: target.targetMessageId,
+        telegramMessageId: target.telegramMessageId,
+      };
+    } catch (error) {
+      return this.failed(action.type, error);
+    }
+  }
+
+  private async executeAskQuestion(
+    context: BehaviorDecisionContext,
+    action: Extract<BehaviorAction, { type: 'ask_question' }>
+  ): Promise<BehaviorActionResult> {
+    try {
+      await this.messenger.sendMessage(
+        context.chatId,
+        this.formatQuestion(action)
+      );
+      return {
+        actionType: action.type,
+        outcome: 'sent',
+        reason: null,
+      };
+    } catch (error) {
+      return this.failed(action.type, error);
+    }
+  }
+
+  private async executeReact(
+    context: BehaviorDecisionContext,
+    action: Extract<BehaviorAction, { type: 'react' }>
+  ): Promise<BehaviorActionResult[]> {
+    const targets = this.resolveSelector(context, action.target);
+    if (targets.length === 0) {
+      return [
+        {
+          actionType: action.type,
+          outcome: 'dropped',
+          reason: 'selector resolved no messages',
+        },
+      ];
+    }
+
+    const results: BehaviorActionResult[] = [];
+    for (const target of targets) {
+      if (target.telegramMessageId === null) {
+        results.push({
+          actionType: action.type,
+          outcome: 'dropped',
+          reason: 'target message has no telegram id',
+          targetMessageId: target.storedMessageId,
+        });
+        continue;
+      }
+
+      try {
+        await this.messenger.reactToMessage(
+          context.chatId,
+          target.telegramMessageId,
+          action.emoji
+        );
+        results.push({
+          actionType: action.type,
+          outcome: 'sent',
+          reason: null,
+          targetMessageId: target.storedMessageId,
+          telegramMessageId: target.telegramMessageId,
+        });
+      } catch (error) {
+        results.push({
+          ...this.failed(action.type, error),
+          targetMessageId: target.storedMessageId,
+          telegramMessageId: target.telegramMessageId,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  private executeSummarizeThread(
+    context: BehaviorDecisionContext,
+    action: Extract<BehaviorAction, { type: 'summarize_thread' }>
+  ): BehaviorActionResult {
+    const result = this.summarizationQueue.enqueueOrBump({
+      chatId: context.chatId,
+      intent: action.intent,
+      reason: action.reason,
+      triggerMessageIds: context.triggerMessageIds,
+      contextMessageIds: context.contextMessageIds,
+      batchMessageIds: context.batchMessageIds,
+    });
+
+    return {
+      actionType: action.type,
+      outcome: result.outcome,
+      reason: result.outcome === 'deferred' ? result.reason : null,
+    };
+  }
+
+  private resolveReplyTarget(
+    context: BehaviorDecisionContext,
+    target: ReplyTarget
+  ):
+    | {
+        outcome: 'resolved';
+        targetMessageId: number | null;
+        telegramMessageId: number | null;
+      }
+    | {
+        outcome: 'dropped';
+        reason: string;
+        targetMessageId?: number;
+      } {
+    if (target.kind === 'none') {
+      return {
+        outcome: 'resolved',
+        targetMessageId: null,
+        telegramMessageId: null,
+      };
+    }
+
+    const targets = this.resolveSelector(context, target.selector);
+    if (targets.length === 0) {
+      return { outcome: 'dropped', reason: 'selector resolved no messages' };
+    }
+
+    const [resolved] = targets;
+    if (resolved.telegramMessageId === null) {
+      return {
+        outcome: 'dropped',
+        reason: 'target message has no telegram id',
+        targetMessageId: resolved.storedMessageId,
+      };
+    }
+
+    return {
+      outcome: 'resolved',
+      targetMessageId: resolved.storedMessageId,
+      telegramMessageId: resolved.telegramMessageId,
+    };
+  }
+
+  private resolveSelector(
+    context: BehaviorDecisionContext,
+    selector: MessageSelector | SingleMessageSelector
+  ): ResolvedMessageTarget[] {
+    const selectedIds = this.selectIds(this.scopeIds(context, selector.scope), selector);
+    const messagesById = new Map(
+      context.messages.map((message) => [message.id, message])
+    );
+
+    return selectedIds.flatMap((id) => {
+      const message = messagesById.get(id);
+      if (!message) {
+        return [];
+      }
+      return [
+        {
+          storedMessageId: id,
+          telegramMessageId: message.messageId ?? null,
+        },
+      ];
+    });
+  }
+
+  private scopeIds(
+    context: BehaviorDecisionContext,
+    scope: MessageSelector['scope']
+  ): number[] {
+    switch (scope) {
+      case 'trigger':
+        return [...context.triggerMessageIds].sort((a, b) => a - b);
+      case 'context':
+        return [...context.contextMessageIds].sort((a, b) => a - b);
+      case 'batch':
+        return [...context.batchMessageIds].sort((a, b) => a - b);
+    }
+  }
+
+  private selectIds(
+    ids: readonly number[],
+    selector: MessageSelector | SingleMessageSelector
+  ): number[] {
+    switch (selector.pick) {
+      case 'first':
+        return ids.length > 0 ? [ids[0]] : [];
+      case 'latest':
+        return ids.length > 0 ? [ids[ids.length - 1]] : [];
+      case 'index':
+        return selector.index < ids.length ? [ids[selector.index]] : [];
+      case 'all':
+        return [...ids];
+    }
+  }
+
+  private formatQuestion(
+    action: Extract<BehaviorAction, { type: 'ask_question' }>
+  ): string {
+    if (!action.targetUsername) {
+      return action.text;
+    }
+
+    const mention = action.targetUsername.startsWith('@')
+      ? action.targetUsername
+      : `@${action.targetUsername}`;
+    return `${mention} ${action.text}`;
+  }
+
+  private failed(
+    actionType: BehaviorAction['type'],
+    error: unknown
+  ): BehaviorActionResult {
+    return {
+      actionType,
+      outcome: 'failed',
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/application/behavior/DefaultBehaviorPipeline.ts
+++ b/src/application/behavior/DefaultBehaviorPipeline.ts
@@ -114,7 +114,11 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
       return { kind: 'ignored', gate };
     }
 
-    return this.decide(batch.chatId, gate);
+    return this.decide(
+      batch.chatId,
+      gate,
+      batch.messages.map((message) => message.id)
+    );
   }
 
   private async processDirectTrigger(
@@ -133,12 +137,17 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
       stateImpactRisk: 'medium',
     };
 
-    return this.decide(chatId, gate);
+    return this.decide(
+      chatId,
+      gate,
+      drained.map((m) => m.id)
+    );
   }
 
   private async decide(
     chatId: number,
-    gate: BehaviorGateDecision
+    gate: BehaviorGateDecision,
+    batchMessageIds: number[]
   ): Promise<BehaviorPipelineResult> {
     let context: BehaviorDecisionContext;
     try {
@@ -146,6 +155,7 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
         chatId,
         triggerMessageIds: gate.triggerMessageIds,
         contextMessageIds: gate.contextMessageIds,
+        batchMessageIds,
         gate,
       });
     } catch (error) {
@@ -160,6 +170,7 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
         inputRef: {
           triggerMessageIds: gate.triggerMessageIds,
           contextMessageIds: gate.contextMessageIds,
+          batchMessageIds,
         },
         fixHint: 'Check context assembler and repositories',
       });
@@ -181,6 +192,7 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
         inputRef: {
           triggerMessageIds: gate.triggerMessageIds,
           contextMessageIds: gate.contextMessageIds,
+          batchMessageIds,
         },
         fixHint: 'Check OpenAI API connectivity and decision schema',
       });

--- a/src/application/behavior/DefaultBehaviorPipeline.ts
+++ b/src/application/behavior/DefaultBehaviorPipeline.ts
@@ -17,6 +17,15 @@ import {
   type BehaviorContextAssembler,
 } from './BehaviorContextAssembler';
 import {
+  BEHAVIOR_DECISION_VALIDATOR_ID,
+  type BehaviorDecisionValidator,
+  type DroppedAction,
+} from './BehaviorDecisionValidator';
+import {
+  BEHAVIOR_EXECUTOR_ID,
+  type BehaviorExecutor,
+} from './BehaviorExecutor';
+import {
   BEHAVIOR_EVENT_LOGGER_ID,
   type BehaviorEventLogger,
 } from './BehaviorEventLogger';
@@ -27,6 +36,7 @@ import {
   type BehaviorPipelineConfig,
 } from './BehaviorConfig';
 import type {
+  BehaviorActionResult,
   BehaviorDecisionContext,
   StoredBehaviorMessage,
 } from './BehaviorTypes';
@@ -35,6 +45,10 @@ import type {
   BehaviorPipelineInput,
   BehaviorPipelineResult,
 } from './BehaviorPipeline';
+import {
+  STATE_PATCH_APPLICATOR_ID,
+  type StatePatchApplicator,
+} from './StatePatchApplicator';
 
 @injectable()
 export class DefaultBehaviorPipeline implements BehaviorPipeline {
@@ -46,6 +60,12 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
     @inject(BEHAVIOR_AI_SERVICE_ID) private readonly ai: BehaviorAiService,
     @inject(BEHAVIOR_CONTEXT_ASSEMBLER_ID)
     private readonly assembler: BehaviorContextAssembler,
+    @inject(BEHAVIOR_DECISION_VALIDATOR_ID)
+    private readonly validator: BehaviorDecisionValidator,
+    @inject(BEHAVIOR_EXECUTOR_ID)
+    private readonly executor: BehaviorExecutor,
+    @inject(STATE_PATCH_APPLICATOR_ID)
+    private readonly patchApplicator: StatePatchApplicator,
     @inject(BEHAVIOR_EVENT_LOGGER_ID)
     private readonly eventLogger: BehaviorEventLogger,
     @inject(AI_ERROR_LOGGER_ID) private readonly errorLogger: AiErrorLogger,
@@ -199,16 +219,67 @@ export class DefaultBehaviorPipeline implements BehaviorPipeline {
       return { kind: 'error', errorEventId };
     }
 
+    const validation = this.validator.validate(decisionResult.decision);
+    if (!validation.ok) {
+      const errorEventId = await this.errorLogger.log({
+        chatId,
+        source: 'behavior_decision_validation',
+        severity: 'error',
+        errorCode: 'DECISION_VALIDATION_FAILED',
+        message: validation.issues.join('; '),
+        component: 'DefaultBehaviorPipeline',
+        operation: 'validateDecision',
+        inputRef: {
+          triggerMessageIds: gate.triggerMessageIds,
+          contextMessageIds: gate.contextMessageIds,
+          batchMessageIds,
+        },
+        outputRef: { issues: validation.issues },
+        fixHint: 'Check behavior decision schema and runtime validator rules',
+      });
+      return { kind: 'error', errorEventId };
+    }
+
+    const sanitizedDecisionResult = {
+      ...decisionResult,
+      decision: validation.decision,
+    };
+    const droppedActionResults = this.toDroppedActionResults(
+      validation.droppedActions
+    );
+    const executedActionResults = await this.executor.execute({
+      context,
+      actions: validation.decision.actions,
+    });
+    const actionResults = [...droppedActionResults, ...executedActionResults];
+    const patchResults = await this.patchApplicator.applyPatches({
+      chatId,
+      patches: validation.decision.statePatches,
+      contextMessages: context.messages,
+    });
+
     const behaviorEventId = await this.eventLogger.logDecision({
       context,
-      result: decisionResult,
+      result: sanitizedDecisionResult,
+      actionResults,
+      patchResults,
     });
 
     return {
       kind: 'decided',
       context,
-      decision: decisionResult.decision,
+      decision: validation.decision,
       behaviorEventId,
     };
+  }
+
+  private toDroppedActionResults(
+    droppedActions: DroppedAction[]
+  ): BehaviorActionResult[] {
+    return droppedActions.map(({ action, reason }) => ({
+      actionType: action.type,
+      outcome: 'dropped',
+      reason,
+    }));
   }
 }

--- a/src/application/behavior/DefaultBehaviorRateLimiter.ts
+++ b/src/application/behavior/DefaultBehaviorRateLimiter.ts
@@ -1,0 +1,99 @@
+import { inject, injectable } from 'inversify';
+
+import type { BehaviorAction } from '@/domain/behavior/schemas/actions';
+import type { LiveStatePatch } from '@/domain/behavior/schemas/patches';
+
+import {
+  BEHAVIOR_RATE_LIMITER_CONFIG_ID,
+  type BehaviorRateLimiterConfig,
+} from './BehaviorConfig';
+import type {
+  BehaviorRateLimiter,
+  BehaviorRateLimitResult,
+} from './BehaviorRateLimiter';
+
+@injectable()
+export class DefaultBehaviorRateLimiter implements BehaviorRateLimiter {
+  private readonly initiativeHits = new Map<number, number[]>();
+  private readonly reactionHits = new Map<number, number[]>();
+  private readonly truthAddHits = new Map<number, number[]>();
+
+  constructor(
+    @inject(BEHAVIOR_RATE_LIMITER_CONFIG_ID)
+    private readonly config: BehaviorRateLimiterConfig
+  ) {}
+
+  checkAction(params: {
+    chatId: number;
+    action: BehaviorAction;
+    nowMs?: number;
+  }): BehaviorRateLimitResult {
+    const nowMs = params.nowMs ?? Date.now();
+
+    switch (params.action.type) {
+      case 'reply':
+      case 'ask_question':
+        return this.checkBucket({
+          chatId: params.chatId,
+          hitsByChat: this.initiativeHits,
+          maxHits: this.config.maxInitiativesPerWindow,
+          nowMs,
+          reason: 'initiative rate limit exceeded',
+          windowMs: this.config.initiativeWindowMs,
+        });
+      case 'react':
+        return this.checkBucket({
+          chatId: params.chatId,
+          hitsByChat: this.reactionHits,
+          maxHits: this.config.maxReactionsPerWindow,
+          nowMs,
+          reason: 'reaction rate limit exceeded',
+          windowMs: this.config.reactionWindowMs,
+        });
+      case 'summarize_thread':
+        return { allowed: true };
+    }
+  }
+
+  checkPatch(params: {
+    chatId: number;
+    patch: LiveStatePatch;
+    nowMs?: number;
+  }): BehaviorRateLimitResult {
+    if (params.patch.type !== 'truth.add') {
+      return { allowed: true };
+    }
+
+    return this.checkBucket({
+      chatId: params.chatId,
+      hitsByChat: this.truthAddHits,
+      maxHits: this.config.maxTruthAddsPerWindow,
+      nowMs: params.nowMs ?? Date.now(),
+      reason: 'truth-add rate limit exceeded',
+      windowMs: this.config.truthAddWindowMs,
+    });
+  }
+
+  private checkBucket(params: {
+    chatId: number;
+    hitsByChat: Map<number, number[]>;
+    maxHits: number;
+    nowMs: number;
+    reason: string;
+    windowMs: number;
+  }): BehaviorRateLimitResult {
+    const cutoff = params.nowMs - params.windowMs;
+    const hits = (params.hitsByChat.get(params.chatId) ?? []).filter(
+      (hit) => hit > cutoff
+    );
+
+    if (hits.length >= params.maxHits) {
+      params.hitsByChat.set(params.chatId, hits);
+      return { allowed: false, reason: params.reason };
+    }
+
+    hits.push(params.nowMs);
+    params.hitsByChat.set(params.chatId, hits);
+    return { allowed: true };
+  }
+}

--- a/src/application/behavior/DefaultBehaviorSummarizationQueue.ts
+++ b/src/application/behavior/DefaultBehaviorSummarizationQueue.ts
@@ -11,9 +11,7 @@ import type {
 } from './BehaviorSummarizationQueue';
 
 @injectable()
-export class DefaultBehaviorSummarizationQueue
-  implements BehaviorSummarizationQueue
-{
+export class DefaultBehaviorSummarizationQueue implements BehaviorSummarizationQueue {
   private readonly pendingByChat = new Map<
     number,
     BehaviorSummarizationRequest

--- a/src/application/behavior/DefaultBehaviorSummarizationQueue.ts
+++ b/src/application/behavior/DefaultBehaviorSummarizationQueue.ts
@@ -1,0 +1,46 @@
+import { inject, injectable } from 'inversify';
+
+import {
+  BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG_ID,
+  type BehaviorSummarizationQueueConfig,
+} from './BehaviorConfig';
+import type {
+  BehaviorSummarizationQueue,
+  BehaviorSummarizationQueueResult,
+  BehaviorSummarizationRequest,
+} from './BehaviorSummarizationQueue';
+
+@injectable()
+export class DefaultBehaviorSummarizationQueue
+  implements BehaviorSummarizationQueue
+{
+  private readonly pendingByChat = new Map<
+    number,
+    BehaviorSummarizationRequest
+  >();
+
+  constructor(
+    @inject(BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG_ID)
+    private readonly config: BehaviorSummarizationQueueConfig
+  ) {}
+
+  enqueueOrBump(
+    request: BehaviorSummarizationRequest
+  ): BehaviorSummarizationQueueResult {
+    if (!this.config.enabled) {
+      return {
+        outcome: 'deferred',
+        reason: 'summarization queue disabled',
+      };
+    }
+
+    const hasPending = this.pendingByChat.has(request.chatId);
+    this.pendingByChat.set(request.chatId, request);
+
+    return { outcome: hasPending ? 'bumped' : 'queued' };
+  }
+
+  peek(chatId: number): BehaviorSummarizationRequest | null {
+    return this.pendingByChat.get(chatId) ?? null;
+  }
+}

--- a/src/application/behavior/DefaultPatchPolicy.ts
+++ b/src/application/behavior/DefaultPatchPolicy.ts
@@ -1,5 +1,6 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
+import { PATCH_POLICY_CONFIG_ID } from './BehaviorConfig';
 import type {
   AnyPatch,
   PatchDecision,
@@ -9,7 +10,9 @@ import type {
 
 @injectable()
 export class DefaultPatchPolicy implements PatchPolicy {
-  constructor(private readonly config: PatchPolicyConfig) {}
+  constructor(
+    @inject(PATCH_POLICY_CONFIG_ID) private readonly config: PatchPolicyConfig
+  ) {}
 
   evaluate(patch: AnyPatch): PatchDecision {
     if (patch.evidence.messageIds.length === 0) {

--- a/src/application/behavior/DefaultStatePatchApplicator.ts
+++ b/src/application/behavior/DefaultStatePatchApplicator.ts
@@ -1,0 +1,533 @@
+import { inject, injectable } from 'inversify';
+
+import type {
+  LiveStatePatch,
+  TruthPatch,
+  UserProfilePatch,
+} from '@/domain/behavior/schemas/patches';
+import type {
+  BotTruth,
+  PatternSignal,
+  SocialSignal,
+  UserSocialProfile,
+} from '@/domain/behavior/schemas/state';
+import {
+  TRUTH_REPOSITORY_ID,
+  type TruthRepository,
+} from '@/domain/repositories/TruthRepository';
+import {
+  USER_SOCIAL_PROFILE_REPOSITORY_ID,
+  type UserSocialProfileRepository,
+} from '@/domain/repositories/UserSocialProfileRepository';
+import type { ChatMessage } from '@/domain/messages/ChatMessage';
+
+import {
+  BEHAVIOR_RATE_LIMITER_ID,
+  type BehaviorRateLimiter,
+} from './BehaviorRateLimiter';
+import type { BehaviorPatchResult } from './BehaviorTypes';
+import { PATCH_POLICY_ID, type PatchPolicy } from './PatchPolicy';
+import {
+  STATE_PATCH_APPLICATOR_CONFIG_ID,
+  type StatePatchApplicator,
+  type StatePatchApplicatorConfig,
+} from './StatePatchApplicator';
+
+interface AcceptedPatch {
+  index: number;
+  patch: LiveStatePatch;
+}
+
+type SignalKind = 'label' | 'pattern' | 'grudge';
+
+@injectable()
+export class DefaultStatePatchApplicator implements StatePatchApplicator {
+  constructor(
+    @inject(STATE_PATCH_APPLICATOR_CONFIG_ID)
+    private readonly config: StatePatchApplicatorConfig,
+    @inject(USER_SOCIAL_PROFILE_REPOSITORY_ID)
+    private readonly profileRepo: UserSocialProfileRepository,
+    @inject(TRUTH_REPOSITORY_ID) private readonly truthRepo: TruthRepository,
+    @inject(PATCH_POLICY_ID) private readonly patchPolicy: PatchPolicy,
+    @inject(BEHAVIOR_RATE_LIMITER_ID)
+    private readonly rateLimiter: BehaviorRateLimiter
+  ) {}
+
+  async applyPatches(params: {
+    chatId: number;
+    patches: readonly LiveStatePatch[];
+    contextMessages: readonly ChatMessage[];
+    nowIso?: string;
+    nowMs?: number;
+  }): Promise<BehaviorPatchResult[]> {
+    const nowIso = params.nowIso ?? new Date().toISOString();
+    const nowMs = params.nowMs ?? Date.now();
+    const results: Array<BehaviorPatchResult | null> = params.patches.map(
+      () => null
+    );
+    const accepted: AcceptedPatch[] = [];
+
+    for (const [index, patch] of params.patches.entries()) {
+      const policy = this.patchPolicy.evaluate(patch);
+      if (policy.outcome !== 'accept') {
+        results[index] = {
+          patchType: patch.type,
+          outcome: 'rejected',
+          reason: policy.reason,
+        };
+        continue;
+      }
+
+      const rateLimit = this.rateLimiter.checkPatch({
+        chatId: params.chatId,
+        patch,
+        nowMs,
+      });
+      if (!rateLimit.allowed) {
+        results[index] = {
+          patchType: patch.type,
+          outcome: 'rate_limited',
+          reason: rateLimit.reason,
+        };
+        continue;
+      }
+
+      accepted.push({ index, patch });
+    }
+
+    await this.applyUserPatches({
+      accepted,
+      chatId: params.chatId,
+      contextMessages: params.contextMessages,
+      nowIso,
+      results,
+    });
+
+    for (const acceptedPatch of accepted) {
+      if (this.isTruthPatch(acceptedPatch.patch)) {
+        results[acceptedPatch.index] = await this.applyTruthPatch({
+          chatId: params.chatId,
+          nowIso,
+          patch: acceptedPatch.patch,
+        });
+      }
+    }
+
+    return results.map(
+      (result, index) =>
+        result ?? {
+          patchType: params.patches[index].type,
+          outcome: 'failed',
+          reason: 'patch was not processed',
+        }
+    );
+  }
+
+  private async applyUserPatches(params: {
+    accepted: AcceptedPatch[];
+    chatId: number;
+    contextMessages: readonly ChatMessage[];
+    nowIso: string;
+    results: Array<BehaviorPatchResult | null>;
+  }): Promise<void> {
+    const byUser = new Map<number, AcceptedPatch[]>();
+
+    for (const acceptedPatch of params.accepted) {
+      if (!this.isUserPatch(acceptedPatch.patch)) {
+        continue;
+      }
+      const patches = byUser.get(acceptedPatch.patch.userId) ?? [];
+      patches.push(acceptedPatch);
+      byUser.set(acceptedPatch.patch.userId, patches);
+    }
+
+    for (const [userId, acceptedPatches] of byUser) {
+      const existing = await this.profileRepo.findByChatAndUser(
+        params.chatId,
+        userId
+      );
+      const profile =
+        existing ?? this.defaultProfile(params.chatId, userId, params.nowIso);
+      const latestUsername = this.latestUsername(params.contextMessages, userId);
+      if (latestUsername !== null && profile.username !== latestUsername) {
+        profile.username = latestUsername;
+      }
+
+      let changed = false;
+      const affinityDelta = acceptedPatches.reduce((sum, acceptedPatch) => {
+        const { patch } = acceptedPatch;
+        return patch.type === 'user.adjust_affinity'
+          ? sum + patch.delta
+          : sum;
+      }, 0);
+
+      if (affinityDelta !== 0) {
+        profile.affinityScore = this.clampAffinity(
+          profile.affinityScore + affinityDelta
+        );
+        changed = true;
+      }
+
+      for (const acceptedPatch of acceptedPatches) {
+        const { patch } = acceptedPatch;
+        if (!this.isUserPatch(patch)) {
+          continue;
+        }
+        if (patch.type === 'user.adjust_affinity') {
+          continue;
+        }
+
+        const applied = this.applyUserSignalPatch(profile, patch);
+        if (applied) {
+          changed = true;
+        } else {
+          params.results[acceptedPatch.index] = {
+            patchType: patch.type,
+            outcome: 'rejected',
+            reason: 'target_not_found',
+          };
+        }
+      }
+
+      if (!changed) {
+        continue;
+      }
+
+      this.recomputeRuntimeFields(profile);
+      profile.updatedAt = params.nowIso;
+      await this.profileRepo.upsert(profile);
+
+      for (const acceptedPatch of acceptedPatches) {
+        if (params.results[acceptedPatch.index] !== null) {
+          continue;
+        }
+        params.results[acceptedPatch.index] = {
+          patchType: acceptedPatch.patch.type,
+          outcome: 'applied',
+          reason: null,
+          stateRef: {
+            kind: 'user_social_profile',
+            chatId: params.chatId,
+            userId,
+          },
+        };
+      }
+    }
+  }
+
+  private applyUserSignalPatch(
+    profile: UserSocialProfile,
+    patch: Exclude<UserProfilePatch, { type: 'user.adjust_affinity' }>
+  ): boolean {
+    switch (patch.type) {
+      case 'user.add_label':
+        profile.labels.push(this.socialSignal(patch.label, patch.evidence.messageIds));
+        return true;
+      case 'user.add_pattern':
+        profile.patterns.push({
+          polarity: patch.polarity,
+          text: patch.text,
+          evidenceMessageIds: patch.evidence.messageIds,
+          status: 'active',
+        });
+        return true;
+      case 'user.add_grudge':
+        profile.grudges.push(this.socialSignal(patch.text, patch.evidence.messageIds));
+        return true;
+      case 'user.contest_profile_signal':
+        return this.contestSignal({
+          evidenceMessageIds: patch.evidence.messageIds,
+          kind: patch.target.kind,
+          profile,
+          text: patch.target.text,
+        });
+    }
+  }
+
+  private async applyTruthPatch(params: {
+    chatId: number;
+    nowIso: string;
+    patch: TruthPatch;
+  }): Promise<BehaviorPatchResult> {
+    const { chatId, nowIso, patch } = params;
+
+    switch (patch.type) {
+      case 'truth.add': {
+        const id = await this.truthRepo.add({
+          chatId,
+          text: patch.text,
+          sourceMessageIds: this.uniqueIds(patch.evidence.messageIds),
+          confidence: this.clampConfidence(patch.evidence.confidence),
+          relatedTruthIds: this.uniqueIds(patch.relatedTruthIds),
+          contradictsTruthIds: this.uniqueIds(patch.contradictsTruthIds),
+          status: this.truthStatus(patch.evidence.confidence),
+          createdAt: nowIso,
+        });
+        return this.appliedTruth(patch.type, chatId, id);
+      }
+      case 'truth.reinforce': {
+        const truth = await this.findMutableTruth(chatId, patch.truthId);
+        if (!truth) {
+          return this.rejectedTruth(patch.type, 'target_not_found');
+        }
+        truth.sourceMessageIds = this.uniqueIds([
+          ...truth.sourceMessageIds,
+          ...patch.evidence.messageIds,
+        ]);
+        truth.confidence = this.clampConfidence(
+          truth.confidence + 0.2 * patch.evidence.confidence
+        );
+        truth.status = this.truthStatus(truth.confidence);
+        await this.truthRepo.update(truth);
+        return this.appliedTruth(patch.type, chatId, truth.id);
+      }
+      case 'truth.contest': {
+        const truth = await this.findMutableTruth(chatId, patch.truthId);
+        if (!truth) {
+          return this.rejectedTruth(patch.type, 'target_not_found');
+        }
+        const counterId = await this.truthRepo.add({
+          chatId,
+          text: patch.counterText,
+          sourceMessageIds: this.uniqueIds(patch.evidence.messageIds),
+          confidence: this.clampConfidence(patch.evidence.confidence),
+          relatedTruthIds: [],
+          contradictsTruthIds: [truth.id],
+          status: this.truthStatus(patch.evidence.confidence),
+          createdAt: nowIso,
+        });
+        truth.contradictsTruthIds = this.uniqueIds([
+          ...truth.contradictsTruthIds,
+          counterId,
+        ]);
+        truth.sourceMessageIds = this.uniqueIds([
+          ...truth.sourceMessageIds,
+          ...patch.evidence.messageIds,
+        ]);
+        truth.confidence = this.clampConfidence(
+          truth.confidence - 0.2 * patch.evidence.confidence
+        );
+        truth.status = 'contested';
+        await this.truthRepo.update(truth);
+        return this.appliedTruth(patch.type, chatId, truth.id);
+      }
+      case 'truth.revise': {
+        const truth = await this.findMutableTruth(chatId, patch.truthId);
+        if (!truth) {
+          return this.rejectedTruth(patch.type, 'target_not_found');
+        }
+        const replacementId = await this.truthRepo.add({
+          chatId,
+          text: patch.revisedText,
+          sourceMessageIds: this.uniqueIds(patch.evidence.messageIds),
+          confidence: this.clampConfidence(
+            Math.max(truth.confidence, patch.evidence.confidence)
+          ),
+          relatedTruthIds: this.uniqueIds([truth.id, ...truth.relatedTruthIds]),
+          contradictsTruthIds: this.uniqueIds(truth.contradictsTruthIds),
+          status: this.truthStatus(
+            Math.max(truth.confidence, patch.evidence.confidence)
+          ),
+          createdAt: nowIso,
+        });
+        truth.status = 'superseded';
+        truth.relatedTruthIds = this.uniqueIds([
+          ...truth.relatedTruthIds,
+          replacementId,
+        ]);
+        await this.truthRepo.update(truth);
+        return this.appliedTruth(patch.type, chatId, replacementId);
+      }
+    }
+  }
+
+  private async findMutableTruth(
+    chatId: number,
+    truthId: number
+  ): Promise<BotTruth | null> {
+    const truth = await this.truthRepo.findById(truthId);
+    if (!truth || truth.chatId !== chatId || truth.status === 'superseded') {
+      return null;
+    }
+    return truth;
+  }
+
+  private contestSignal(params: {
+    evidenceMessageIds: number[];
+    kind: SignalKind;
+    profile: UserSocialProfile;
+    text: string;
+  }): boolean {
+    const signal = this.findLatestSignal(
+      this.signalsByKind(params.profile, params.kind),
+      params.text
+    );
+    if (!signal) {
+      return false;
+    }
+
+    signal.evidenceMessageIds = this.uniqueIds([
+      ...signal.evidenceMessageIds,
+      ...params.evidenceMessageIds,
+    ]);
+    signal.status = signal.status === 'active' ? 'contested' : 'inactive';
+    return true;
+  }
+
+  private signalsByKind(
+    profile: UserSocialProfile,
+    kind: SignalKind
+  ): Array<SocialSignal | PatternSignal> {
+    switch (kind) {
+      case 'label':
+        return profile.labels;
+      case 'pattern':
+        return profile.patterns;
+      case 'grudge':
+        return profile.grudges;
+    }
+  }
+
+  private findLatestSignal(
+    signals: Array<SocialSignal | PatternSignal>,
+    text: string
+  ): SocialSignal | PatternSignal | null {
+    for (let index = signals.length - 1; index >= 0; index -= 1) {
+      const signal = signals[index];
+      if (signal.text === text && signal.status !== 'inactive') {
+        return signal;
+      }
+    }
+    return null;
+  }
+
+  private defaultProfile(
+    chatId: number,
+    userId: number,
+    nowIso: string
+  ): UserSocialProfile {
+    return {
+      userId,
+      chatId,
+      username: null,
+      affinityScore: 0,
+      labels: [],
+      patterns: [],
+      grudges: [],
+      trustLevel: 'none',
+      preferredDistance: 'neutral',
+      communicationStyle: '',
+      conflictStyle: '',
+      preferredTone: '',
+      interests: [],
+      updatedAt: nowIso,
+    };
+  }
+
+  private latestUsername(
+    messages: readonly ChatMessage[],
+    userId: number
+  ): string | null {
+    const matching = messages
+      .filter((message) => message.userId === userId && message.username)
+      .sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+    return matching.length > 0
+      ? matching[matching.length - 1].username ?? null
+      : null;
+  }
+
+  private recomputeRuntimeFields(profile: UserSocialProfile): void {
+    const activeGrudges = profile.grudges.filter(
+      (signal) => signal.status === 'active'
+    ).length;
+    const activeNegativePatterns = profile.patterns.filter(
+      (signal) => signal.status === 'active' && signal.polarity === 'negative'
+    ).length;
+
+    if (profile.affinityScore >= 2 && activeGrudges === 0) {
+      profile.trustLevel = 'high';
+    } else if (profile.affinityScore >= 1 && activeGrudges === 0) {
+      profile.trustLevel = 'medium';
+    } else if (profile.affinityScore >= 0) {
+      profile.trustLevel = 'low';
+    } else {
+      profile.trustLevel = 'none';
+    }
+
+    if (activeGrudges >= 2 || profile.affinityScore <= -3) {
+      profile.preferredDistance = 'hostile';
+    } else if (activeGrudges === 1) {
+      profile.preferredDistance = 'avoidant';
+    } else if (activeNegativePatterns >= 2) {
+      profile.preferredDistance = 'mocking';
+    } else if (profile.affinityScore <= -1) {
+      profile.preferredDistance = 'cold';
+    } else if (profile.affinityScore >= 2) {
+      profile.preferredDistance = 'warm';
+    } else {
+      profile.preferredDistance = 'neutral';
+    }
+  }
+
+  private socialSignal(text: string, evidenceMessageIds: number[]): SocialSignal {
+    return {
+      text,
+      evidenceMessageIds,
+      status: 'active',
+    };
+  }
+
+  private truthStatus(confidence: number): BotTruth['status'] {
+    return this.clampConfidence(confidence) >= this.config.truthStableConfidence
+      ? 'stable'
+      : 'fresh';
+  }
+
+  private appliedTruth(
+    patchType: TruthPatch['type'],
+    chatId: number,
+    truthId: number
+  ): BehaviorPatchResult {
+    return {
+      patchType,
+      outcome: 'applied',
+      reason: null,
+      stateRef: {
+        kind: 'bot_truth',
+        chatId,
+        truthId,
+      },
+    };
+  }
+
+  private rejectedTruth(
+    patchType: TruthPatch['type'],
+    reason: string
+  ): BehaviorPatchResult {
+    return {
+      patchType,
+      outcome: 'rejected',
+      reason,
+    };
+  }
+
+  private isUserPatch(patch: LiveStatePatch): patch is UserProfilePatch {
+    return patch.type.startsWith('user.');
+  }
+
+  private isTruthPatch(patch: LiveStatePatch): patch is TruthPatch {
+    return patch.type.startsWith('truth.');
+  }
+
+  private clampAffinity(value: number): number {
+    return Math.max(-3, Math.min(3, value));
+  }
+
+  private clampConfidence(value: number): number {
+    return Math.max(0, Math.min(1, value));
+  }
+
+  private uniqueIds(ids: readonly number[]): number[] {
+    return [...new Set(ids)];
+  }
+}

--- a/src/application/behavior/DefaultStatePatchApplicator.ts
+++ b/src/application/behavior/DefaultStatePatchApplicator.ts
@@ -148,7 +148,10 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
       );
       const profile =
         existing ?? this.defaultProfile(params.chatId, userId, params.nowIso);
-      const latestUsername = this.latestUsername(params.contextMessages, userId);
+      const latestUsername = this.latestUsername(
+        params.contextMessages,
+        userId
+      );
       if (latestUsername !== null && profile.username !== latestUsername) {
         profile.username = latestUsername;
       }
@@ -156,9 +159,7 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
       let changed = false;
       const affinityDelta = acceptedPatches.reduce((sum, acceptedPatch) => {
         const { patch } = acceptedPatch;
-        return patch.type === 'user.adjust_affinity'
-          ? sum + patch.delta
-          : sum;
+        return patch.type === 'user.adjust_affinity' ? sum + patch.delta : sum;
       }, 0);
 
       if (affinityDelta !== 0) {
@@ -221,7 +222,9 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
   ): boolean {
     switch (patch.type) {
       case 'user.add_label':
-        profile.labels.push(this.socialSignal(patch.label, patch.evidence.messageIds));
+        profile.labels.push(
+          this.socialSignal(patch.label, patch.evidence.messageIds)
+        );
         return true;
       case 'user.add_pattern':
         profile.patterns.push({
@@ -232,7 +235,9 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
         });
         return true;
       case 'user.add_grudge':
-        profile.grudges.push(this.socialSignal(patch.text, patch.evidence.messageIds));
+        profile.grudges.push(
+          this.socialSignal(patch.text, patch.evidence.messageIds)
+        );
         return true;
       case 'user.contest_profile_signal':
         return this.contestSignal({
@@ -432,7 +437,7 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
       .filter((message) => message.userId === userId && message.username)
       .sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
     return matching.length > 0
-      ? matching[matching.length - 1].username ?? null
+      ? (matching[matching.length - 1].username ?? null)
       : null;
   }
 
@@ -469,7 +474,10 @@ export class DefaultStatePatchApplicator implements StatePatchApplicator {
     }
   }
 
-  private socialSignal(text: string, evidenceMessageIds: number[]): SocialSignal {
+  private socialSignal(
+    text: string,
+    evidenceMessageIds: number[]
+  ): SocialSignal {
     return {
       text,
       evidenceMessageIds,

--- a/src/application/behavior/StatePatchApplicator.ts
+++ b/src/application/behavior/StatePatchApplicator.ts
@@ -1,0 +1,33 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { LiveStatePatch } from '@/domain/behavior/schemas/patches';
+import type { ChatMessage } from '@/domain/messages/ChatMessage';
+
+import type { BehaviorPatchResult } from './BehaviorTypes';
+
+export interface StatePatchApplicatorConfig {
+  truthStableConfidence: number;
+}
+
+export const DEFAULT_STATE_PATCH_APPLICATOR_CONFIG: StatePatchApplicatorConfig =
+  {
+    truthStableConfidence: 0.75,
+  };
+
+export interface StatePatchApplicator {
+  applyPatches(params: {
+    chatId: number;
+    patches: readonly LiveStatePatch[];
+    contextMessages: readonly ChatMessage[];
+    nowIso?: string;
+    nowMs?: number;
+  }): Promise<BehaviorPatchResult[]>;
+}
+
+export const STATE_PATCH_APPLICATOR_CONFIG_ID = Symbol.for(
+  'StatePatchApplicatorConfig'
+) as ServiceIdentifier<StatePatchApplicatorConfig>;
+
+export const STATE_PATCH_APPLICATOR_ID = Symbol.for(
+  'StatePatchApplicator'
+) as ServiceIdentifier<StatePatchApplicator>;

--- a/src/application/interfaces/chat/ChatMessenger.ts
+++ b/src/application/interfaces/chat/ChatMessenger.ts
@@ -4,6 +4,11 @@ import type { ServiceIdentifier } from 'inversify';
 export interface ChatMessenger {
   readonly bot: Bot<Context>;
   sendMessage(chatId: number, text: string, extra?: object): Promise<void>;
+  reactToMessage(
+    chatId: number,
+    messageId: number,
+    emoji: string
+  ): Promise<void>;
   launch(): Promise<void>;
   stop(reason: string): void;
 }

--- a/src/application/prompts/PromptBuilder.ts
+++ b/src/application/prompts/PromptBuilder.ts
@@ -300,12 +300,20 @@ export class PromptBuilder {
       const template = await this.templates.loadTemplate('behaviorMessages');
       const triggerSet = new Set(markers?.triggerMessageIds ?? []);
       const contextSet = new Set(markers?.contextMessageIds ?? []);
+      const batchSet = new Set(markers?.batchMessageIds ?? []);
       const lines = messages.map((m) => {
-        const marker = triggerSet.has(m.id)
-          ? ' [TRIGGER]'
-          : contextSet.has(m.id)
-            ? ' [GATE_CONTEXT]'
-            : '';
+        const markerParts = [];
+        if (triggerSet.has(m.id)) {
+          markerParts.push('[TRIGGER]');
+        }
+        if (contextSet.has(m.id)) {
+          markerParts.push('[GATE_CONTEXT]');
+        }
+        if (batchSet.has(m.id)) {
+          markerParts.push('[BATCH]');
+        }
+        const marker =
+          markerParts.length > 0 ? ` ${markerParts.join(' ')}` : '';
         const fullName =
           m.fullName ??
           ([m.firstName, m.lastName].filter(Boolean).join(' ') || 'N/A');

--- a/src/application/prompts/PromptDirector.ts
+++ b/src/application/prompts/PromptDirector.ts
@@ -109,6 +109,7 @@ export class PromptDirector {
       .addBehaviorMessages(context.messages, {
         triggerMessageIds: context.triggerMessageIds,
         contextMessageIds: context.contextMessageIds,
+        batchMessageIds: context.batchMessageIds,
       })
       .build();
   }

--- a/src/application/prompts/PromptTypes.ts
+++ b/src/application/prompts/PromptTypes.ts
@@ -27,6 +27,7 @@ export interface BehaviorPromptState {
 export interface BehaviorMessageMarkers {
   triggerMessageIds: readonly number[];
   contextMessageIds: readonly number[];
+  batchMessageIds: readonly number[];
 }
 
 export interface BehaviorPromptContext {
@@ -34,5 +35,6 @@ export interface BehaviorPromptContext {
   messages: BehaviorPromptMessage[];
   triggerMessageIds: number[];
   contextMessageIds: number[];
+  batchMessageIds: number[];
   state: BehaviorPromptState;
 }

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -19,10 +19,16 @@ import {
 import {
   BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID,
   BEHAVIOR_PIPELINE_CONFIG_ID,
+  BEHAVIOR_RATE_LIMITER_CONFIG_ID,
+  BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG_ID,
   DEFAULT_BEHAVIOR_DECISION_VALIDATOR_CONFIG,
   DEFAULT_BEHAVIOR_PIPELINE_CONFIG,
+  DEFAULT_BEHAVIOR_RATE_LIMITER_CONFIG,
+  DEFAULT_BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG,
   DEFAULT_PATCH_POLICY_CONFIG,
   PATCH_POLICY_CONFIG_ID,
+  type BehaviorRateLimiterConfig,
+  type BehaviorSummarizationQueueConfig,
   type BehaviorPipelineConfig,
 } from '../application/behavior/BehaviorConfig';
 import {
@@ -30,6 +36,10 @@ import {
   type BehaviorDecisionValidator,
   type BehaviorDecisionValidatorConfig,
 } from '../application/behavior/BehaviorDecisionValidator';
+import {
+  BEHAVIOR_EXECUTOR_ID,
+  type BehaviorExecutor,
+} from '../application/behavior/BehaviorExecutor';
 import {
   BEHAVIOR_CONTEXT_ASSEMBLER_ID,
   type BehaviorContextAssembler,
@@ -46,13 +56,32 @@ import { DefaultAiErrorLogger } from '../application/behavior/DefaultAiErrorLogg
 import { DefaultBehaviorContextAssembler } from '../application/behavior/DefaultBehaviorContextAssembler';
 import { DefaultBehaviorDecisionValidator } from '../application/behavior/DefaultBehaviorDecisionValidator';
 import { DefaultBehaviorEventLogger } from '../application/behavior/DefaultBehaviorEventLogger';
+import { DefaultBehaviorExecutor } from '../application/behavior/DefaultBehaviorExecutor';
 import { DefaultBehaviorPipeline } from '../application/behavior/DefaultBehaviorPipeline';
+import { DefaultBehaviorRateLimiter } from '../application/behavior/DefaultBehaviorRateLimiter';
+import { DefaultBehaviorSummarizationQueue } from '../application/behavior/DefaultBehaviorSummarizationQueue';
 import { DefaultPatchPolicy } from '../application/behavior/DefaultPatchPolicy';
+import { DefaultStatePatchApplicator } from '../application/behavior/DefaultStatePatchApplicator';
+import {
+  BEHAVIOR_RATE_LIMITER_ID,
+  type BehaviorRateLimiter,
+} from '../application/behavior/BehaviorRateLimiter';
+import {
+  BEHAVIOR_SUMMARIZATION_QUEUE_ID,
+  type BehaviorSummarizationQueue,
+} from '../application/behavior/BehaviorSummarizationQueue';
 import {
   PATCH_POLICY_ID,
   type PatchPolicy,
   type PatchPolicyConfig,
 } from '../application/behavior/PatchPolicy';
+import {
+  DEFAULT_STATE_PATCH_APPLICATOR_CONFIG,
+  STATE_PATCH_APPLICATOR_CONFIG_ID,
+  STATE_PATCH_APPLICATOR_ID,
+  type StatePatchApplicator,
+  type StatePatchApplicatorConfig,
+} from '../application/behavior/StatePatchApplicator';
 import {
   CHAT_APPROVAL_SERVICE_ID,
   type ChatApprovalService,
@@ -211,6 +240,20 @@ export const register = (container: Container): void => {
     .toConstantValue(DEFAULT_PATCH_POLICY_CONFIG);
 
   container
+    .bind<BehaviorRateLimiterConfig>(BEHAVIOR_RATE_LIMITER_CONFIG_ID)
+    .toConstantValue(DEFAULT_BEHAVIOR_RATE_LIMITER_CONFIG);
+
+  container
+    .bind<BehaviorSummarizationQueueConfig>(
+      BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG_ID
+    )
+    .toConstantValue(DEFAULT_BEHAVIOR_SUMMARIZATION_QUEUE_CONFIG);
+
+  container
+    .bind<StatePatchApplicatorConfig>(STATE_PATCH_APPLICATOR_CONFIG_ID)
+    .toConstantValue(DEFAULT_STATE_PATCH_APPLICATOR_CONFIG);
+
+  container
     .bind<AIService>(AI_SERVICE_ID)
     .to(ChatGPTService)
     .inSingletonScope();
@@ -233,6 +276,26 @@ export const register = (container: Container): void => {
   container
     .bind<PatchPolicy>(PATCH_POLICY_ID)
     .to(DefaultPatchPolicy)
+    .inSingletonScope();
+
+  container
+    .bind<BehaviorRateLimiter>(BEHAVIOR_RATE_LIMITER_ID)
+    .to(DefaultBehaviorRateLimiter)
+    .inSingletonScope();
+
+  container
+    .bind<BehaviorSummarizationQueue>(BEHAVIOR_SUMMARIZATION_QUEUE_ID)
+    .to(DefaultBehaviorSummarizationQueue)
+    .inSingletonScope();
+
+  container
+    .bind<BehaviorExecutor>(BEHAVIOR_EXECUTOR_ID)
+    .to(DefaultBehaviorExecutor)
+    .inSingletonScope();
+
+  container
+    .bind<StatePatchApplicator>(STATE_PATCH_APPLICATOR_ID)
+    .to(DefaultStatePatchApplicator)
     .inSingletonScope();
 
   container

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -17,10 +17,19 @@ import {
   type BehaviorAiService,
 } from '../application/behavior/BehaviorAiService';
 import {
+  BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID,
   BEHAVIOR_PIPELINE_CONFIG_ID,
+  DEFAULT_BEHAVIOR_DECISION_VALIDATOR_CONFIG,
   DEFAULT_BEHAVIOR_PIPELINE_CONFIG,
+  DEFAULT_PATCH_POLICY_CONFIG,
+  PATCH_POLICY_CONFIG_ID,
   type BehaviorPipelineConfig,
 } from '../application/behavior/BehaviorConfig';
+import {
+  BEHAVIOR_DECISION_VALIDATOR_ID,
+  type BehaviorDecisionValidator,
+  type BehaviorDecisionValidatorConfig,
+} from '../application/behavior/BehaviorDecisionValidator';
 import {
   BEHAVIOR_CONTEXT_ASSEMBLER_ID,
   type BehaviorContextAssembler,
@@ -35,8 +44,15 @@ import {
 } from '../application/behavior/BehaviorPipeline';
 import { DefaultAiErrorLogger } from '../application/behavior/DefaultAiErrorLogger';
 import { DefaultBehaviorContextAssembler } from '../application/behavior/DefaultBehaviorContextAssembler';
+import { DefaultBehaviorDecisionValidator } from '../application/behavior/DefaultBehaviorDecisionValidator';
 import { DefaultBehaviorEventLogger } from '../application/behavior/DefaultBehaviorEventLogger';
 import { DefaultBehaviorPipeline } from '../application/behavior/DefaultBehaviorPipeline';
+import { DefaultPatchPolicy } from '../application/behavior/DefaultPatchPolicy';
+import {
+  PATCH_POLICY_ID,
+  type PatchPolicy,
+  type PatchPolicyConfig,
+} from '../application/behavior/PatchPolicy';
 import {
   CHAT_APPROVAL_SERVICE_ID,
   type ChatApprovalService,
@@ -185,6 +201,16 @@ export const register = (container: Container): void => {
     .toConstantValue(DEFAULT_BEHAVIOR_PIPELINE_CONFIG);
 
   container
+    .bind<BehaviorDecisionValidatorConfig>(
+      BEHAVIOR_DECISION_VALIDATOR_CONFIG_ID
+    )
+    .toConstantValue(DEFAULT_BEHAVIOR_DECISION_VALIDATOR_CONFIG);
+
+  container
+    .bind<PatchPolicyConfig>(PATCH_POLICY_CONFIG_ID)
+    .toConstantValue(DEFAULT_PATCH_POLICY_CONFIG);
+
+  container
     .bind<AIService>(AI_SERVICE_ID)
     .to(ChatGPTService)
     .inSingletonScope();
@@ -197,6 +223,16 @@ export const register = (container: Container): void => {
   container
     .bind<BehaviorContextAssembler>(BEHAVIOR_CONTEXT_ASSEMBLER_ID)
     .to(DefaultBehaviorContextAssembler)
+    .inSingletonScope();
+
+  container
+    .bind<BehaviorDecisionValidator>(BEHAVIOR_DECISION_VALIDATOR_ID)
+    .to(DefaultBehaviorDecisionValidator)
+    .inSingletonScope();
+
+  container
+    .bind<PatchPolicy>(PATCH_POLICY_ID)
+    .to(DefaultPatchPolicy)
     .inSingletonScope();
 
   container

--- a/src/view/telegram/TelegramMessenger.ts
+++ b/src/view/telegram/TelegramMessenger.ts
@@ -1,5 +1,11 @@
 import { conversations } from '@grammyjs/conversations';
-import { Bot, type Context, GrammyError, HttpError, session } from 'grammy';
+import {
+  Bot,
+  type Context,
+  GrammyError,
+  HttpError,
+  session,
+} from 'grammy';
 import { inject, injectable } from 'inversify';
 
 import type { ChatMessenger } from '@/application/interfaces/chat/ChatMessenger';
@@ -71,5 +77,15 @@ export class TelegramMessenger implements ChatMessenger {
     extra?: object
   ): Promise<void> {
     await this._bot.api.sendMessage(chatId, text, extra);
+  }
+
+  async reactToMessage(
+    chatId: number,
+    messageId: number,
+    emoji: string
+  ): Promise<void> {
+    await this._bot.api.setMessageReaction(chatId, messageId, [
+      { type: 'emoji', emoji: emoji as never },
+    ]);
   }
 }

--- a/src/view/telegram/TelegramMessenger.ts
+++ b/src/view/telegram/TelegramMessenger.ts
@@ -1,11 +1,5 @@
 import { conversations } from '@grammyjs/conversations';
-import {
-  Bot,
-  type Context,
-  GrammyError,
-  HttpError,
-  session,
-} from 'grammy';
+import { Bot, type Context, GrammyError, HttpError, session } from 'grammy';
 import { inject, injectable } from 'inversify';
 
 import type { ChatMessenger } from '@/application/interfaces/chat/ChatMessenger';

--- a/test/BehaviorContextAssembler.test.ts
+++ b/test/BehaviorContextAssembler.test.ts
@@ -138,6 +138,27 @@ describe('DefaultBehaviorContextAssembler', () => {
     expect(ctx.messages.map((m) => m.id)).toEqual([1, 2, 3]);
   });
 
+  it('includes batch message ids in selected lookup and context', async () => {
+    const selected: ChatMessage[] = [
+      { id: 1, chatId: 1, role: 'user', content: 'trigger' },
+      { id: 2, chatId: 1, role: 'user', content: 'context' },
+      { id: 4, chatId: 1, role: 'user', content: 'batch' },
+    ];
+    const { assembler, messages } = makeAssembler({ selected });
+
+    const ctx = await assembler.assemble({
+      chatId: 1,
+      triggerMessageIds: [1],
+      contextMessageIds: [2],
+      batchMessageIds: [4],
+      gate,
+    });
+
+    expect(messages.getMessagesByIds).toHaveBeenCalledWith([1, 2, 4]);
+    expect(ctx.batchMessageIds).toEqual([4]);
+    expect(ctx.messages.map((m) => m.id)).toEqual([1, 2, 4]);
+  });
+
   it('includes summary, profiles, and truths', async () => {
     const { assembler } = makeAssembler({ summary: 'prev-summary' });
     const ctx = await assembler.assemble({

--- a/test/BehaviorEventLogger.test.ts
+++ b/test/BehaviorEventLogger.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { DefaultBehaviorEventLogger } from '../src/application/behavior/DefaultBehaviorEventLogger';
 import type { BehaviorEventRepository } from '../src/domain/repositories/BehaviorEventRepository';
 import type {
+  BehaviorActionResult,
   BehaviorAiDecisionResult,
   BehaviorDecisionContext,
+  BehaviorPatchResult,
 } from '../src/application/behavior/BehaviorTypes';
 
 function makeContext(): BehaviorDecisionContext {
@@ -86,6 +88,51 @@ describe('DefaultBehaviorEventLogger', () => {
         completionTokens: 5,
         totalTokens: 15,
         latencyMs: 150,
+      })
+    );
+  });
+
+  it('persists action and patch results when provided', async () => {
+    const repo: BehaviorEventRepository = {
+      insert: vi.fn().mockResolvedValue(43),
+      findById: vi.fn(),
+      findByChatId: vi.fn(),
+    } as unknown as BehaviorEventRepository;
+
+    const actionResults: BehaviorActionResult[] = [
+      {
+        actionType: 'react',
+        outcome: 'sent',
+        reason: null,
+        targetMessageId: 2,
+        telegramMessageId: 200,
+      },
+    ];
+    const patchResults: BehaviorPatchResult[] = [
+      {
+        patchType: 'truth.add',
+        outcome: 'applied',
+        reason: null,
+        stateRef: {
+          kind: 'bot_truth',
+          truthId: 10,
+          chatId: 1,
+        },
+      },
+    ];
+
+    const logger = new DefaultBehaviorEventLogger(repo);
+    await logger.logDecision({
+      context: makeContext(),
+      result: makeResult(),
+      actionResults,
+      patchResults,
+    });
+
+    expect(repo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionResultsJson: JSON.stringify(actionResults),
+        patchResultsJson: JSON.stringify(patchResults),
       })
     );
   });

--- a/test/BehaviorExecutor.test.ts
+++ b/test/BehaviorExecutor.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DefaultBehaviorExecutor } from '../src/application/behavior/DefaultBehaviorExecutor';
+import type { BehaviorRateLimiter } from '../src/application/behavior/BehaviorRateLimiter';
+import type { BehaviorSummarizationQueue } from '../src/application/behavior/BehaviorSummarizationQueue';
+import type { BehaviorDecisionContext } from '../src/application/behavior/BehaviorTypes';
+import type { ChatMessenger } from '../src/application/interfaces/chat/ChatMessenger';
+import type { BehaviorAction } from '../src/domain/behavior/schemas/actions';
+
+const allowingLimiter: BehaviorRateLimiter = {
+  checkAction: vi.fn(() => ({ allowed: true })),
+  checkPatch: vi.fn(() => ({ allowed: true })),
+};
+
+function makeMessenger(overrides?: Partial<ChatMessenger>): ChatMessenger {
+  return {
+    bot: {} as ChatMessenger['bot'],
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    reactToMessage: vi.fn().mockResolvedValue(undefined),
+    launch: vi.fn(),
+    stop: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeQueue(
+  outcome: 'queued' | 'bumped' | 'deferred' = 'queued'
+): BehaviorSummarizationQueue {
+  return {
+    enqueueOrBump: vi.fn(() =>
+      outcome === 'deferred'
+        ? { outcome, reason: 'summarization queue disabled' }
+        : { outcome }
+    ),
+  };
+}
+
+function makeContext(): BehaviorDecisionContext {
+  return {
+    chatId: 1,
+    gate: {
+      shouldDecide: true,
+      confidence: 0.9,
+      reason: 'conflict',
+      triggerMessageIds: [1],
+      contextMessageIds: [2],
+      stateImpactRisk: 'medium',
+    },
+    summary: '',
+    triggerMessageIds: [1],
+    contextMessageIds: [2],
+    batchMessageIds: [3, 4],
+    messages: [
+      {
+        id: 1,
+        chatId: 1,
+        role: 'user',
+        content: 'trigger',
+        messageId: 101,
+      },
+      { id: 2, chatId: 1, role: 'user', content: 'context' },
+      { id: 3, chatId: 1, role: 'user', content: 'batch', messageId: 103 },
+      { id: 4, chatId: 1, role: 'user', content: 'batch2', messageId: 104 },
+    ],
+    state: {
+      personality: {} as BehaviorDecisionContext['state']['personality'],
+      political: {} as BehaviorDecisionContext['state']['political'],
+      profiles: [],
+      truths: [],
+    },
+  };
+}
+
+describe('DefaultBehaviorExecutor', () => {
+  it('sends reply and ask_question actions through ChatMessenger', async () => {
+    const messenger = makeMessenger();
+    const executor = new DefaultBehaviorExecutor(
+      messenger,
+      allowingLimiter,
+      makeQueue()
+    );
+    const actions: BehaviorAction[] = [
+      {
+        type: 'reply',
+        intent: 'direct_answer',
+        text: 'answer',
+        target: {
+          kind: 'message',
+          selector: { scope: 'trigger', pick: 'latest', index: null },
+        },
+      },
+      {
+        type: 'ask_question',
+        intent: 'clarify',
+        text: 'what changed?',
+        targetUsername: 'alice',
+      },
+    ];
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions,
+      nowMs: 1_000,
+    });
+
+    expect(messenger.sendMessage).toHaveBeenNthCalledWith(1, 1, 'answer', {
+      reply_parameters: { message_id: 101 },
+    });
+    expect(messenger.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      1,
+      '@alice what changed?'
+    );
+    expect(results.map((result) => result.outcome)).toEqual(['sent', 'sent']);
+  });
+
+  it('reacts to selector targets and drops selected messages without Telegram ids', async () => {
+    const messenger = makeMessenger();
+    const executor = new DefaultBehaviorExecutor(
+      messenger,
+      allowingLimiter,
+      makeQueue()
+    );
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions: [
+        {
+          type: 'react',
+          intent: 'acknowledgement',
+          emoji: '👍',
+          target: { scope: 'context', pick: 'latest', index: null },
+        },
+        {
+          type: 'react',
+          intent: 'acknowledgement',
+          emoji: '🔥',
+          target: { scope: 'batch', pick: 'all', index: null },
+        },
+      ],
+      nowMs: 1_000,
+    });
+
+    expect(messenger.reactToMessage).toHaveBeenNthCalledWith(1, 1, 103, '🔥');
+    expect(messenger.reactToMessage).toHaveBeenNthCalledWith(2, 1, 104, '🔥');
+    expect(results).toEqual([
+      {
+        actionType: 'react',
+        outcome: 'dropped',
+        reason: 'target message has no telegram id',
+        targetMessageId: 2,
+      },
+      {
+        actionType: 'react',
+        outcome: 'sent',
+        reason: null,
+        targetMessageId: 3,
+        telegramMessageId: 103,
+      },
+      {
+        actionType: 'react',
+        outcome: 'sent',
+        reason: null,
+        targetMessageId: 4,
+        telegramMessageId: 104,
+      },
+    ]);
+  });
+
+  it('queues summarize_thread and returns no results for empty actions', async () => {
+    const queue = makeQueue('bumped');
+    const executor = new DefaultBehaviorExecutor(
+      makeMessenger(),
+      allowingLimiter,
+      queue
+    );
+
+    await expect(
+      executor.execute({ context: makeContext(), actions: [] })
+    ).resolves.toEqual([]);
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions: [
+        {
+          type: 'summarize_thread',
+          intent: 'compress_context',
+          reason: 'too long',
+        },
+      ],
+    });
+
+    expect(queue.enqueueOrBump).toHaveBeenCalledWith({
+      chatId: 1,
+      intent: 'compress_context',
+      reason: 'too long',
+      triggerMessageIds: [1],
+      contextMessageIds: [2],
+      batchMessageIds: [3, 4],
+    });
+    expect(results).toEqual([
+      {
+        actionType: 'summarize_thread',
+        outcome: 'bumped',
+        reason: null,
+      },
+    ]);
+  });
+
+  it('drops invalid selectors without calling Telegram', async () => {
+    const messenger = makeMessenger();
+    const executor = new DefaultBehaviorExecutor(
+      messenger,
+      allowingLimiter,
+      makeQueue()
+    );
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions: [
+        {
+          type: 'reply',
+          intent: 'direct_answer',
+          text: 'answer',
+          target: {
+            kind: 'message',
+            selector: { scope: 'context', pick: 'index', index: 5 },
+          },
+        },
+      ],
+    });
+
+    expect(messenger.sendMessage).not.toHaveBeenCalled();
+    expect(results).toEqual([
+      {
+        actionType: 'reply',
+        outcome: 'dropped',
+        reason: 'selector resolved no messages',
+      },
+    ]);
+  });
+
+  it('records Telegram failures as failed action results', async () => {
+    const messenger = makeMessenger({
+      sendMessage: vi.fn().mockRejectedValue(new Error('telegram down')),
+    });
+    const executor = new DefaultBehaviorExecutor(
+      messenger,
+      allowingLimiter,
+      makeQueue()
+    );
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions: [
+        {
+          type: 'reply',
+          intent: 'direct_answer',
+          text: 'answer',
+          target: { kind: 'none' },
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        actionType: 'reply',
+        outcome: 'failed',
+        reason: 'telegram down',
+      },
+    ]);
+  });
+
+  it('drops rate-limited actions before Telegram or queue work', async () => {
+    const messenger = makeMessenger();
+    const queue = makeQueue();
+    const limiter: BehaviorRateLimiter = {
+      checkAction: vi.fn(() => ({
+        allowed: false,
+        reason: 'initiative rate limit exceeded',
+      })),
+      checkPatch: vi.fn(() => ({ allowed: true })),
+    };
+    const executor = new DefaultBehaviorExecutor(messenger, limiter, queue);
+
+    const results = await executor.execute({
+      context: makeContext(),
+      actions: [
+        {
+          type: 'ask_question',
+          intent: 'clarify',
+          text: 'what changed?',
+          targetUsername: null,
+        },
+      ],
+    });
+
+    expect(messenger.sendMessage).not.toHaveBeenCalled();
+    expect(queue.enqueueOrBump).not.toHaveBeenCalled();
+    expect(results).toEqual([
+      {
+        actionType: 'ask_question',
+        outcome: 'rate_limited',
+        reason: 'initiative rate limit exceeded',
+      },
+    ]);
+  });
+});

--- a/test/BehaviorPipeline.test.ts
+++ b/test/BehaviorPipeline.test.ts
@@ -4,8 +4,11 @@ import { DefaultBehaviorPipeline } from '../src/application/behavior/DefaultBeha
 import { DEFAULT_BEHAVIOR_PIPELINE_CONFIG } from '../src/application/behavior/BehaviorConfig';
 import type { BehaviorAiService } from '../src/application/behavior/BehaviorAiService';
 import type { BehaviorContextAssembler } from '../src/application/behavior/BehaviorContextAssembler';
+import type { BehaviorDecisionValidator } from '../src/application/behavior/BehaviorDecisionValidator';
+import type { BehaviorExecutor } from '../src/application/behavior/BehaviorExecutor';
 import type { BehaviorEventLogger } from '../src/application/behavior/BehaviorEventLogger';
 import type { AiErrorLogger } from '../src/application/behavior/AiErrorLogger';
+import type { StatePatchApplicator } from '../src/application/behavior/StatePatchApplicator';
 import type {
   StoredBehaviorMessage,
   DirectBehaviorTrigger,
@@ -96,6 +99,7 @@ const mockContext: BehaviorDecisionContext = {
   messages: [],
   triggerMessageIds: [1],
   contextMessageIds: [],
+  batchMessageIds: [1, 2],
   state: {
     personality: {} as any,
     political: {} as any,
@@ -107,6 +111,9 @@ const mockContext: BehaviorDecisionContext = {
 function makePipeline(overrides: {
   ai?: Partial<BehaviorAiService>;
   assembler?: Partial<BehaviorContextAssembler>;
+  validator?: Partial<BehaviorDecisionValidator>;
+  executor?: Partial<BehaviorExecutor>;
+  applicator?: Partial<StatePatchApplicator>;
   eventLogger?: Partial<BehaviorEventLogger>;
   errorLogger?: Partial<AiErrorLogger>;
 }) {
@@ -120,6 +127,25 @@ function makePipeline(overrides: {
     assemble: vi.fn().mockResolvedValue(mockContext),
     ...overrides.assembler,
   } as unknown as BehaviorContextAssembler;
+
+  const validator: BehaviorDecisionValidator = {
+    validate: vi.fn().mockReturnValue({
+      ok: true,
+      decision: decisionResult.decision,
+      droppedActions: [],
+    }),
+    ...overrides.validator,
+  } as unknown as BehaviorDecisionValidator;
+
+  const executor: BehaviorExecutor = {
+    execute: vi.fn().mockResolvedValue([]),
+    ...overrides.executor,
+  } as unknown as BehaviorExecutor;
+
+  const applicator: StatePatchApplicator = {
+    applyPatches: vi.fn().mockResolvedValue([]),
+    ...overrides.applicator,
+  } as unknown as StatePatchApplicator;
 
   const eventLogger: BehaviorEventLogger = {
     logDecision: vi.fn().mockResolvedValue(99),
@@ -135,12 +161,24 @@ function makePipeline(overrides: {
     config,
     ai,
     assembler,
+    validator,
+    executor,
+    applicator,
     eventLogger,
     errorLogger,
     createLoggerFactory()
   );
 
-  return { pipeline, ai, assembler, eventLogger, errorLogger };
+  return {
+    pipeline,
+    ai,
+    assembler,
+    validator,
+    executor,
+    applicator,
+    eventLogger,
+    errorLogger,
+  };
 }
 
 describe('DefaultBehaviorPipeline', () => {
@@ -171,6 +209,17 @@ describe('DefaultBehaviorPipeline', () => {
       smallConfig,
       ai2,
       assembler2,
+      {
+        validate: vi.fn().mockReturnValue({
+          ok: true,
+          decision: decisionResult.decision,
+          droppedActions: [],
+        }),
+      } as unknown as BehaviorDecisionValidator,
+      { execute: vi.fn().mockResolvedValue([]) } as unknown as BehaviorExecutor,
+      {
+        applyPatches: vi.fn().mockResolvedValue([]),
+      } as unknown as StatePatchApplicator,
       eventLogger2,
       errorLogger2,
       createLoggerFactory()
@@ -195,6 +244,9 @@ describe('DefaultBehaviorPipeline', () => {
         decideBehavior: vi.fn(),
       } as unknown as BehaviorAiService,
       { assemble: vi.fn() } as unknown as BehaviorContextAssembler,
+      { validate: vi.fn() } as unknown as BehaviorDecisionValidator,
+      { execute: vi.fn() } as unknown as BehaviorExecutor,
+      { applyPatches: vi.fn() } as unknown as StatePatchApplicator,
       { logDecision: vi.fn() } as unknown as BehaviorEventLogger,
       { log: vi.fn() } as unknown as AiErrorLogger,
       createLoggerFactory()
@@ -230,6 +282,128 @@ describe('DefaultBehaviorPipeline', () => {
     expect(eventLogger.logDecision).toHaveBeenCalledOnce();
   });
 
+  it('validates, executes, applies patches, and logs final runtime results', async () => {
+    const action = {
+      type: 'reply',
+      intent: 'direct_answer',
+      text: 'sanitized answer',
+      target: { kind: 'none' },
+    } as const;
+    const patch = {
+      type: 'truth.add',
+      text: 'new truth',
+      relatedTruthIds: [],
+      contradictsTruthIds: [],
+      evidence: { messageIds: [1], summary: 's', confidence: 0.8 },
+    } as const;
+    const sanitizedDecision = {
+      confidence: 0.8,
+      actions: [action],
+      statePatches: [patch],
+      safetyNotes: [],
+    };
+    const actionResults = [
+      { actionType: 'reply' as const, outcome: 'sent' as const, reason: null },
+    ];
+    const patchResults = [
+      {
+        patchType: 'truth.add' as const,
+        outcome: 'applied' as const,
+        reason: null,
+      },
+    ];
+    const { pipeline, validator, executor, applicator, eventLogger } =
+      makePipeline({
+        ai: {
+          decideBehavior: vi.fn().mockResolvedValue({
+            decision: {
+              confidence: 0.8,
+              actions: [action],
+              statePatches: [patch],
+              safetyNotes: [],
+            },
+            metadata: decisionResult.metadata,
+          }),
+        },
+        validator: {
+          validate: vi.fn().mockReturnValue({
+            ok: true,
+            decision: sanitizedDecision,
+            droppedActions: [],
+          }),
+        },
+        executor: { execute: vi.fn().mockResolvedValue(actionResults) },
+        applicator: { applyPatches: vi.fn().mockResolvedValue(patchResults) },
+      });
+
+    const result = await pipeline.handleStoredMessage({
+      message: makeMsg(1),
+      directTrigger: {
+        reason: 'direct_trigger',
+        why: 'mentioned',
+        triggerMessageId: 1,
+        replyToTelegramMessageId: null,
+      },
+    });
+
+    expect(validator.validate).toHaveBeenCalledWith(
+      expect.objectContaining({ actions: [action], statePatches: [patch] })
+    );
+    expect(executor.execute).toHaveBeenCalledWith({
+      context: mockContext,
+      actions: sanitizedDecision.actions,
+    });
+    expect(applicator.applyPatches).toHaveBeenCalledWith({
+      chatId: 1,
+      patches: sanitizedDecision.statePatches,
+      contextMessages: mockContext.messages,
+    });
+    expect(eventLogger.logDecision).toHaveBeenCalledWith({
+      context: mockContext,
+      result: expect.objectContaining({ decision: sanitizedDecision }),
+      actionResults,
+      patchResults,
+    });
+    expect(result.kind).toBe('decided');
+    if (result.kind === 'decided') {
+      expect(result.decision).toBe(sanitizedDecision);
+    }
+  });
+
+  it('logs invalid AI decisions without executing actions or patches', async () => {
+    const { pipeline, executor, applicator, eventLogger, errorLogger } =
+      makePipeline({
+        validator: {
+          validate: vi.fn().mockReturnValue({
+            ok: false,
+            errorCode: 'behavior_decision_validation',
+            issues: ['actions.0: invalid'],
+          }),
+        },
+      });
+
+    const result = await pipeline.handleStoredMessage({
+      message: makeMsg(1),
+      directTrigger: {
+        reason: 'direct_trigger',
+        why: 'mentioned',
+        triggerMessageId: 1,
+        replyToTelegramMessageId: null,
+      },
+    });
+
+    expect(result).toEqual({ kind: 'error', errorEventId: 55 });
+    expect(executor.execute).not.toHaveBeenCalled();
+    expect(applicator.applyPatches).not.toHaveBeenCalled();
+    expect(eventLogger.logDecision).not.toHaveBeenCalled();
+    expect(errorLogger.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'behavior_decision_validation',
+        errorCode: 'DECISION_VALIDATION_FAILED',
+      })
+    );
+  });
+
   it('returns error and logs AI error when gate fails', async () => {
     const smallConfig = { ...config, batchSizeCap: 1 };
     const failingAi: BehaviorAiService = {
@@ -243,6 +417,9 @@ describe('DefaultBehaviorPipeline', () => {
       smallConfig,
       failingAi,
       { assemble: vi.fn() } as unknown as BehaviorContextAssembler,
+      { validate: vi.fn() } as unknown as BehaviorDecisionValidator,
+      { execute: vi.fn() } as unknown as BehaviorExecutor,
+      { applyPatches: vi.fn() } as unknown as StatePatchApplicator,
       { logDecision: vi.fn() } as unknown as BehaviorEventLogger,
       errorLogger,
       createLoggerFactory()
@@ -273,6 +450,9 @@ describe('DefaultBehaviorPipeline', () => {
       {
         assemble: vi.fn().mockResolvedValue(mockContext),
       } as unknown as BehaviorContextAssembler,
+      { validate: vi.fn() } as unknown as BehaviorDecisionValidator,
+      { execute: vi.fn() } as unknown as BehaviorExecutor,
+      { applyPatches: vi.fn() } as unknown as StatePatchApplicator,
       { logDecision: vi.fn() } as unknown as BehaviorEventLogger,
       errorLogger,
       createLoggerFactory()

--- a/test/BehaviorRateLimiter.test.ts
+++ b/test/BehaviorRateLimiter.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { DefaultBehaviorRateLimiter } from '../src/application/behavior/DefaultBehaviorRateLimiter';
+import type { BehaviorRateLimiterConfig } from '../src/application/behavior/BehaviorConfig';
+import type { BehaviorAction } from '../src/domain/behavior/schemas/actions';
+import type { LiveStatePatch } from '../src/domain/behavior/schemas/patches';
+
+const config: BehaviorRateLimiterConfig = {
+  initiativeWindowMs: 1_000,
+  maxInitiativesPerWindow: 2,
+  reactionWindowMs: 1_000,
+  maxReactionsPerWindow: 1,
+  truthAddWindowMs: 1_000,
+  maxTruthAddsPerWindow: 1,
+};
+
+const replyAction: BehaviorAction = {
+  type: 'reply',
+  intent: 'banter',
+  text: 'ok',
+  target: { kind: 'none' },
+};
+
+const reactAction: BehaviorAction = {
+  type: 'react',
+  intent: 'acknowledgement',
+  emoji: '👍',
+  target: { scope: 'trigger', pick: 'latest', index: null },
+};
+
+const summarizeAction: BehaviorAction = {
+  type: 'summarize_thread',
+  intent: 'compress_context',
+  reason: 'long thread',
+};
+
+const truthAddPatch: LiveStatePatch = {
+  type: 'truth.add',
+  text: 'Carl likes bounded writes',
+  relatedTruthIds: [],
+  contradictsTruthIds: [],
+  evidence: {
+    messageIds: [1],
+    summary: 'stated directly',
+    confidence: 0.8,
+  },
+};
+
+describe('DefaultBehaviorRateLimiter', () => {
+  it('limits initiative actions per chat within a sliding window', () => {
+    const limiter = new DefaultBehaviorRateLimiter(config);
+
+    expect(
+      limiter.checkAction({ chatId: 1, action: replyAction, nowMs: 1_000 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkAction({ chatId: 1, action: replyAction, nowMs: 1_500 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkAction({ chatId: 1, action: replyAction, nowMs: 1_900 })
+    ).toEqual({
+      allowed: false,
+      reason: 'initiative rate limit exceeded',
+    });
+    expect(
+      limiter.checkAction({ chatId: 1, action: replyAction, nowMs: 2_001 })
+    ).toEqual({ allowed: true });
+  });
+
+  it('limits reactions independently from initiative actions', () => {
+    const limiter = new DefaultBehaviorRateLimiter(config);
+
+    expect(
+      limiter.checkAction({ chatId: 1, action: replyAction, nowMs: 1_000 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkAction({ chatId: 1, action: reactAction, nowMs: 1_100 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkAction({ chatId: 1, action: reactAction, nowMs: 1_200 })
+    ).toEqual({
+      allowed: false,
+      reason: 'reaction rate limit exceeded',
+    });
+    expect(
+      limiter.checkAction({ chatId: 2, action: reactAction, nowMs: 1_200 })
+    ).toEqual({ allowed: true });
+  });
+
+  it('does not rate-limit summarize_thread actions', () => {
+    const limiter = new DefaultBehaviorRateLimiter(config);
+
+    expect(
+      limiter.checkAction({ chatId: 1, action: summarizeAction, nowMs: 1_000 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkAction({ chatId: 1, action: summarizeAction, nowMs: 1_000 })
+    ).toEqual({ allowed: true });
+  });
+
+  it('limits truth-add patches independently from other patch types', () => {
+    const limiter = new DefaultBehaviorRateLimiter(config);
+
+    expect(
+      limiter.checkPatch({ chatId: 1, patch: truthAddPatch, nowMs: 1_000 })
+    ).toEqual({ allowed: true });
+    expect(
+      limiter.checkPatch({ chatId: 1, patch: truthAddPatch, nowMs: 1_500 })
+    ).toEqual({
+      allowed: false,
+      reason: 'truth-add rate limit exceeded',
+    });
+    expect(
+      limiter.checkPatch({
+        chatId: 1,
+        patch: {
+          type: 'truth.reinforce',
+          truthId: 1,
+          evidence: truthAddPatch.evidence,
+        },
+        nowMs: 1_500,
+      })
+    ).toEqual({ allowed: true });
+  });
+});

--- a/test/BehaviorSummarizationQueue.test.ts
+++ b/test/BehaviorSummarizationQueue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { DefaultBehaviorSummarizationQueue } from '../src/application/behavior/DefaultBehaviorSummarizationQueue';
+import type { BehaviorSummarizationQueueConfig } from '../src/application/behavior/BehaviorConfig';
+
+const enabledConfig: BehaviorSummarizationQueueConfig = {
+  enabled: true,
+};
+
+function request(reason: string) {
+  return {
+    chatId: 1,
+    intent: 'compress_context' as const,
+    reason,
+    triggerMessageIds: [1],
+    contextMessageIds: [2],
+    batchMessageIds: [3],
+  };
+}
+
+describe('DefaultBehaviorSummarizationQueue', () => {
+  it('queues the first summarize-thread request for a chat', () => {
+    const queue = new DefaultBehaviorSummarizationQueue(enabledConfig);
+
+    expect(queue.enqueueOrBump(request('first'))).toEqual({
+      outcome: 'queued',
+    });
+  });
+
+  it('bumps an existing pending request for the same chat', () => {
+    const queue = new DefaultBehaviorSummarizationQueue(enabledConfig);
+
+    expect(queue.enqueueOrBump(request('first'))).toEqual({
+      outcome: 'queued',
+    });
+    expect(queue.enqueueOrBump(request('second'))).toEqual({
+      outcome: 'bumped',
+    });
+    expect(queue.peek(1)?.reason).toBe('second');
+  });
+
+  it('defers requests when the queue is disabled', () => {
+    const queue = new DefaultBehaviorSummarizationQueue({ enabled: false });
+
+    expect(queue.enqueueOrBump(request('first'))).toEqual({
+      outcome: 'deferred',
+      reason: 'summarization queue disabled',
+    });
+    expect(queue.peek(1)).toBeNull();
+  });
+});

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -33,7 +33,7 @@ describe('logger', () => {
     const child = logger.child({ service: 'test' });
     child.info('child');
     expect(typeof child.info).toBe('function');
-  });
+  }, 10_000);
 
   it('child logger respects EnvService log level', async () => {
     process.env.LOG_LEVEL = 'info';

--- a/test/PromptBuilder.test.ts
+++ b/test/PromptBuilder.test.ts
@@ -143,18 +143,27 @@ describe('PromptBuilder', () => {
         content: 'hi',
         userId: 0,
       } as BehaviorPromptMessage,
+      {
+        id: 3,
+        chatId: 10,
+        role: 'user',
+        content: 'batch',
+        userId: 8,
+      } as BehaviorPromptMessage,
     ];
     const builder = new PromptBuilder(templates);
     const result = await builder
       .addBehaviorMessages(msgs, {
         triggerMessageIds: [1],
         contextMessageIds: [2],
+        batchMessageIds: [3],
       })
       .build();
     expect(result[0].role).toBe('user');
     expect(result[0].content).toContain('[storeId:1]');
     expect(result[0].content).toContain('[TRIGGER]');
     expect(result[0].content).toContain('[GATE_CONTEXT]');
+    expect(result[0].content).toContain('[BATCH]');
   });
 
   it('clears steps after build', async () => {

--- a/test/StatePatchApplicator.test.ts
+++ b/test/StatePatchApplicator.test.ts
@@ -188,7 +188,14 @@ describe('DefaultStatePatchApplicator', () => {
       },
     ];
     const contextMessages: ChatMessage[] = [
-      { id: 1, chatId: 1, userId: 7, username: 'old', role: 'user', content: 'a' },
+      {
+        id: 1,
+        chatId: 1,
+        userId: 7,
+        username: 'old',
+        role: 'user',
+        content: 'a',
+      },
       {
         id: 7,
         chatId: 1,

--- a/test/StatePatchApplicator.test.ts
+++ b/test/StatePatchApplicator.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DefaultStatePatchApplicator } from '../src/application/behavior/DefaultStatePatchApplicator';
+import type { BehaviorRateLimiter } from '../src/application/behavior/BehaviorRateLimiter';
+import type { PatchPolicy } from '../src/application/behavior/PatchPolicy';
+import type { StatePatchApplicatorConfig } from '../src/application/behavior/StatePatchApplicator';
+import type {
+  LiveStatePatch,
+  TruthPatch,
+  UserProfilePatch,
+} from '../src/domain/behavior/schemas/patches';
+import type {
+  BotTruth,
+  UserSocialProfile,
+} from '../src/domain/behavior/schemas/state';
+import type { TruthRepository } from '../src/domain/repositories/TruthRepository';
+import type { UserSocialProfileRepository } from '../src/domain/repositories/UserSocialProfileRepository';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage';
+
+const config: StatePatchApplicatorConfig = {
+  truthStableConfidence: 0.75,
+};
+
+const acceptingPolicy: PatchPolicy = {
+  evaluate: vi.fn(() => ({ outcome: 'accept', reason: 'ok' })),
+};
+
+const allowingLimiter: BehaviorRateLimiter = {
+  checkAction: vi.fn(() => ({ allowed: true })),
+  checkPatch: vi.fn(() => ({ allowed: true })),
+};
+
+function evidence(ids: number[], confidence = 0.8) {
+  return {
+    messageIds: ids,
+    summary: 'evidence',
+    confidence,
+  };
+}
+
+function makeProfile(overrides: Partial<UserSocialProfile>): UserSocialProfile {
+  return {
+    userId: 1,
+    chatId: 1,
+    username: null,
+    affinityScore: 0,
+    labels: [],
+    patterns: [],
+    grudges: [],
+    trustLevel: 'low',
+    preferredDistance: 'neutral',
+    communicationStyle: '',
+    conflictStyle: '',
+    preferredTone: '',
+    interests: [],
+    updatedAt: 'old',
+    ...overrides,
+  };
+}
+
+function makeTruth(overrides: Partial<BotTruth>): BotTruth {
+  return {
+    id: 1,
+    chatId: 1,
+    text: 'old truth',
+    sourceMessageIds: [1],
+    confidence: 0.5,
+    relatedTruthIds: [],
+    contradictsTruthIds: [],
+    status: 'fresh',
+    createdAt: 'old',
+    ...overrides,
+  };
+}
+
+function makeRepos(params?: {
+  profile?: UserSocialProfile;
+  truths?: BotTruth[];
+}) {
+  const profiles = new Map<string, UserSocialProfile>();
+  if (params?.profile) {
+    profiles.set(
+      `${params.profile.chatId}:${params.profile.userId}`,
+      params.profile
+    );
+  }
+
+  const truths = new Map<number, BotTruth>();
+  for (const truth of params?.truths ?? []) {
+    truths.set(truth.id, truth);
+  }
+  let nextTruthId = Math.max(0, ...truths.keys()) + 1;
+
+  const profileRepo: UserSocialProfileRepository = {
+    findByChatAndUser: vi.fn((chatId: number, userId: number) =>
+      Promise.resolve(profiles.get(`${chatId}:${userId}`))
+    ),
+    findByChat: vi.fn(),
+    upsert: vi.fn((profile: UserSocialProfile) => {
+      profiles.set(`${profile.chatId}:${profile.userId}`, profile);
+      return Promise.resolve();
+    }),
+  };
+
+  const truthRepo: TruthRepository = {
+    add: vi.fn((truth) => {
+      const id = nextTruthId;
+      nextTruthId += 1;
+      truths.set(id, { id, ...truth });
+      return Promise.resolve(id);
+    }),
+    findById: vi.fn((id: number) => Promise.resolve(truths.get(id))),
+    findByChatId: vi.fn((chatId: number) =>
+      Promise.resolve([...truths.values()].filter((t) => t.chatId === chatId))
+    ),
+    update: vi.fn((truth: BotTruth) => {
+      truths.set(truth.id, truth);
+      return Promise.resolve();
+    }),
+  };
+
+  return { profileRepo, profiles, truthRepo, truths };
+}
+
+function makeApplicator(params?: {
+  profileRepo?: UserSocialProfileRepository;
+  truthRepo?: TruthRepository;
+  policy?: PatchPolicy;
+  limiter?: BehaviorRateLimiter;
+}) {
+  const repos = makeRepos();
+  return new DefaultStatePatchApplicator(
+    config,
+    params?.profileRepo ?? repos.profileRepo,
+    params?.truthRepo ?? repos.truthRepo,
+    params?.policy ?? acceptingPolicy,
+    params?.limiter ?? allowingLimiter
+  );
+}
+
+describe('DefaultStatePatchApplicator', () => {
+  it('creates profiles, updates username, sums affinity, appends signals, and recomputes runtime fields', async () => {
+    const { profileRepo, profiles, truthRepo } = makeRepos();
+    const applicator = makeApplicator({ profileRepo, truthRepo });
+    const patches: UserProfilePatch[] = [
+      {
+        type: 'user.adjust_affinity',
+        userId: 7,
+        delta: 1,
+        evidence: evidence([1]),
+      },
+      {
+        type: 'user.adjust_affinity',
+        userId: 7,
+        delta: 1,
+        evidence: evidence([2]),
+      },
+      {
+        type: 'user.adjust_affinity',
+        userId: 7,
+        delta: 1,
+        evidence: evidence([3]),
+      },
+      {
+        type: 'user.adjust_affinity',
+        userId: 7,
+        delta: 1,
+        evidence: evidence([4]),
+      },
+      {
+        type: 'user.add_label',
+        userId: 7,
+        label: 'reliable',
+        evidence: evidence([5]),
+      },
+      {
+        type: 'user.add_pattern',
+        userId: 7,
+        polarity: 'negative',
+        text: 'snaps in arguments',
+        evidence: evidence([6]),
+      },
+      {
+        type: 'user.add_grudge',
+        userId: 7,
+        text: 'kept poking Carl',
+        evidence: evidence([7]),
+      },
+    ];
+    const contextMessages: ChatMessage[] = [
+      { id: 1, chatId: 1, userId: 7, username: 'old', role: 'user', content: 'a' },
+      {
+        id: 7,
+        chatId: 1,
+        userId: 7,
+        username: 'alice',
+        role: 'user',
+        content: 'b',
+      },
+    ];
+
+    const results = await applicator.applyPatches({
+      chatId: 1,
+      patches,
+      contextMessages,
+      nowIso: 'now',
+      nowMs: 1_000,
+    });
+
+    expect(results.every((result) => result.outcome === 'applied')).toBe(true);
+    expect(profileRepo.upsert).toHaveBeenCalledTimes(1);
+    const profile = profiles.get('1:7');
+    expect(profile?.username).toBe('alice');
+    expect(profile?.affinityScore).toBe(3);
+    expect(profile?.labels[0]).toEqual({
+      text: 'reliable',
+      evidenceMessageIds: [5],
+      status: 'active',
+    });
+    expect(profile?.patterns[0]?.polarity).toBe('negative');
+    expect(profile?.grudges).toHaveLength(1);
+    expect(profile?.trustLevel).toBe('low');
+    expect(profile?.preferredDistance).toBe('avoidant');
+  });
+
+  it('contests profile signals active to contested to inactive without deleting them', async () => {
+    const { profileRepo, profiles, truthRepo } = makeRepos({
+      profile: makeProfile({
+        labels: [
+          { text: 'reliable', evidenceMessageIds: [1], status: 'active' },
+        ],
+      }),
+    });
+    const applicator = makeApplicator({ profileRepo, truthRepo });
+    const patches: UserProfilePatch[] = [
+      {
+        type: 'user.contest_profile_signal',
+        userId: 1,
+        target: { kind: 'label', text: 'reliable' },
+        evidence: evidence([2]),
+      },
+      {
+        type: 'user.contest_profile_signal',
+        userId: 1,
+        target: { kind: 'label', text: 'reliable' },
+        evidence: evidence([3]),
+      },
+    ];
+
+    const results = await applicator.applyPatches({
+      chatId: 1,
+      patches,
+      contextMessages: [],
+      nowIso: 'now',
+      nowMs: 1_000,
+    });
+
+    expect(results.every((result) => result.outcome === 'applied')).toBe(true);
+    expect(profiles.get('1:1')?.labels).toEqual([
+      {
+        text: 'reliable',
+        evidenceMessageIds: [1, 2, 3],
+        status: 'inactive',
+      },
+    ]);
+  });
+
+  it('applies truth add, reinforce, contest, and revise semantics', async () => {
+    const existing = makeTruth({
+      id: 10,
+      confidence: 0.5,
+      sourceMessageIds: [1],
+    });
+    const { profileRepo, truthRepo, truths } = makeRepos({
+      truths: [existing],
+    });
+    const applicator = makeApplicator({ profileRepo, truthRepo });
+    const patches: TruthPatch[] = [
+      {
+        type: 'truth.add',
+        text: 'new stable truth',
+        relatedTruthIds: [10, 10],
+        contradictsTruthIds: [],
+        evidence: evidence([2, 2], 0.9),
+      },
+      {
+        type: 'truth.reinforce',
+        truthId: 10,
+        evidence: evidence([3], 0.5),
+      },
+      {
+        type: 'truth.contest',
+        truthId: 10,
+        counterText: 'counter truth',
+        evidence: evidence([4], 0.5),
+      },
+      {
+        type: 'truth.revise',
+        truthId: 10,
+        revisedText: 'replacement truth',
+        evidence: evidence([5], 0.9),
+      },
+    ];
+
+    const results = await applicator.applyPatches({
+      chatId: 1,
+      patches,
+      contextMessages: [],
+      nowIso: 'now',
+      nowMs: 1_000,
+    });
+
+    expect(results.every((result) => result.outcome === 'applied')).toBe(true);
+    const addedTruth = truths.get(11);
+    expect(addedTruth).toMatchObject({
+      text: 'new stable truth',
+      sourceMessageIds: [2],
+      relatedTruthIds: [10],
+      confidence: 0.9,
+      status: 'stable',
+    });
+    expect(truths.get(12)).toMatchObject({
+      text: 'counter truth',
+      contradictsTruthIds: [10],
+    });
+    expect(truths.get(13)).toMatchObject({
+      text: 'replacement truth',
+      relatedTruthIds: [10],
+      confidence: 0.9,
+      status: 'stable',
+    });
+    expect(truths.get(10)).toMatchObject({
+      status: 'superseded',
+      relatedTruthIds: [13],
+      contradictsTruthIds: [12],
+    });
+  });
+
+  it('rejects patches denied by policy without blocking unrelated patches', async () => {
+    const { profileRepo, profiles, truthRepo } = makeRepos();
+    const policy: PatchPolicy = {
+      evaluate: vi.fn((patch: LiveStatePatch) =>
+        patch.type === 'user.add_grudge'
+          ? { outcome: 'reject', reason: 'policy denied' }
+          : { outcome: 'accept', reason: 'ok' }
+      ),
+    };
+    const applicator = makeApplicator({ profileRepo, truthRepo, policy });
+
+    const results = await applicator.applyPatches({
+      chatId: 1,
+      patches: [
+        {
+          type: 'user.add_grudge',
+          userId: 1,
+          text: 'bad',
+          evidence: evidence([1]),
+        },
+        {
+          type: 'user.add_label',
+          userId: 1,
+          label: 'fine',
+          evidence: evidence([2]),
+        },
+      ],
+      contextMessages: [],
+      nowIso: 'now',
+      nowMs: 1_000,
+    });
+
+    expect(results.map((result) => result.outcome)).toEqual([
+      'rejected',
+      'applied',
+    ]);
+    expect(profiles.get('1:1')?.labels).toHaveLength(1);
+    expect(profiles.get('1:1')?.grudges).toHaveLength(0);
+  });
+
+  it('rate-limits truth.add without blocking non-creation truth patches', async () => {
+    const { profileRepo, truthRepo } = makeRepos({
+      truths: [makeTruth({ id: 1 })],
+    });
+    const limiter: BehaviorRateLimiter = {
+      checkAction: vi.fn(() => ({ allowed: true })),
+      checkPatch: vi.fn((params) =>
+        params.patch.type === 'truth.add'
+          ? { allowed: false, reason: 'truth-add rate limit exceeded' }
+          : { allowed: true }
+      ),
+    };
+    const applicator = makeApplicator({ profileRepo, truthRepo, limiter });
+
+    const results = await applicator.applyPatches({
+      chatId: 1,
+      patches: [
+        {
+          type: 'truth.add',
+          text: 'too many truths',
+          relatedTruthIds: [],
+          contradictsTruthIds: [],
+          evidence: evidence([1]),
+        },
+        {
+          type: 'truth.reinforce',
+          truthId: 1,
+          evidence: evidence([2]),
+        },
+      ],
+      contextMessages: [],
+      nowIso: 'now',
+      nowMs: 1_000,
+    });
+
+    expect(results.map((result) => result.outcome)).toEqual([
+      'rate_limited',
+      'applied',
+    ]);
+    expect(truthRepo.add).not.toHaveBeenCalled();
+    expect(truthRepo.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/container.behavior.test.ts
+++ b/test/container.behavior.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { BEHAVIOR_DECISION_VALIDATOR_ID } from '../src/application/behavior/BehaviorDecisionValidator';
+import { BEHAVIOR_EXECUTOR_ID } from '../src/application/behavior/BehaviorExecutor';
 import { BEHAVIOR_PIPELINE_ID } from '../src/application/behavior/BehaviorPipeline';
+import { BEHAVIOR_RATE_LIMITER_ID } from '../src/application/behavior/BehaviorRateLimiter';
+import { BEHAVIOR_SUMMARIZATION_QUEUE_ID } from '../src/application/behavior/BehaviorSummarizationQueue';
 import { PATCH_POLICY_ID } from '../src/application/behavior/PatchPolicy';
+import { STATE_PATCH_APPLICATOR_ID } from '../src/application/behavior/StatePatchApplicator';
 import { container } from '../src/container';
 
 describe('behavior DI', () => {
@@ -53,5 +57,12 @@ describe('behavior DI', () => {
         },
       })
     ).toEqual({ outcome: 'accept', reason: 'patch accepted' });
+  });
+
+  it('resolves phase 3 behavior services', () => {
+    expect(container.get(BEHAVIOR_RATE_LIMITER_ID)).toBeTruthy();
+    expect(container.get(BEHAVIOR_SUMMARIZATION_QUEUE_ID)).toBeTruthy();
+    expect(container.get(BEHAVIOR_EXECUTOR_ID)).toBeTruthy();
+    expect(container.get(STATE_PATCH_APPLICATOR_ID)).toBeTruthy();
   });
 });

--- a/test/container.behavior.test.ts
+++ b/test/container.behavior.test.ts
@@ -1,10 +1,57 @@
 import { describe, expect, it } from 'vitest';
 
+import { BEHAVIOR_DECISION_VALIDATOR_ID } from '../src/application/behavior/BehaviorDecisionValidator';
 import { BEHAVIOR_PIPELINE_ID } from '../src/application/behavior/BehaviorPipeline';
+import { PATCH_POLICY_ID } from '../src/application/behavior/PatchPolicy';
 import { container } from '../src/container';
 
 describe('behavior DI', () => {
   it('resolves the behavior pipeline', () => {
     expect(container.get(BEHAVIOR_PIPELINE_ID)).toBeTruthy();
+  });
+
+  it('resolves behavior validator and policy with default config', () => {
+    const validator = container.get(BEHAVIOR_DECISION_VALIDATOR_ID);
+    const policy = container.get(PATCH_POLICY_ID);
+
+    const validation = validator.validate({
+      confidence: 0.8,
+      actions: [
+        {
+          type: 'react',
+          intent: 'acknowledgement',
+          emoji: '💀',
+          target: { scope: 'trigger', pick: 'latest', index: null },
+        },
+        {
+          type: 'react',
+          intent: 'acknowledgement',
+          emoji: '🧪',
+          target: { scope: 'context', pick: 'latest', index: null },
+        },
+      ],
+      statePatches: [],
+      safetyNotes: [],
+    });
+
+    expect(validation.ok).toBe(true);
+    if (validation.ok) {
+      expect(validation.decision.actions).toHaveLength(1);
+      expect(validation.droppedActions).toHaveLength(1);
+    }
+
+    expect(
+      policy.evaluate({
+        type: 'truth.add',
+        text: 'Carl likes structured logs',
+        relatedTruthIds: [],
+        contradictsTruthIds: [],
+        evidence: {
+          messageIds: [1],
+          summary: 'User stated it directly',
+          confidence: 0.8,
+        },
+      })
+    ).toEqual({ outcome: 'accept', reason: 'patch accepted' });
   });
 });


### PR DESCRIPTION
## Summary
- Add Phase 3 behavior execution services for replies, questions, reactions, summarize queueing, rate limiting, and live user/truth patch application.
- Thread batch selector context through prompts and pipeline validation, and record runtime action/patch results in behavior events.
- Integrate validation, execution, live patch application, and final event logging into `DefaultBehaviorPipeline`.

## Test Plan
- Focused Phase 3 Vitest suite: 43 passed
- Full Vitest suite: 225 passed
- TypeScript typecheck
- oxlint
- oxfmt --check
- rsbuild build

Created from branch `feat/ai-behavior-evolution-phase-3`.